### PR TITLE
Refactor dual-barrel firing for OrnithopterA and TankCombat

### DIFF
--- a/Red Strike/Assets/Scenes/SampleScene.unity
+++ b/Red Strike/Assets/Scenes/SampleScene.unity
@@ -4900,25 +4900,9 @@ PrefabInstance:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: -2782345837604721076, guid: a35a82b670e35ac4aa3594152075595d, type: 3}
-      propertyPath: bankSpeed
-      value: 30
-      objectReference: {fileID: 0}
-    - target: {fileID: -2782345837604721076, guid: a35a82b670e35ac4aa3594152075595d, type: 3}
-      propertyPath: maxBankAngle
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: -2782345837604721076, guid: a35a82b670e35ac4aa3594152075595d, type: 3}
       propertyPath: targetObject
       value: 
       objectReference: {fileID: 460729958}
-    - target: {fileID: -2782345837604721076, guid: a35a82b670e35ac4aa3594152075595d, type: 3}
-      propertyPath: attackAltitude
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: -2782345837604721076, guid: a35a82b670e35ac4aa3594152075595d, type: 3}
-      propertyPath: attackLobeRadius
-      value: 50
-      objectReference: {fileID: 0}
     - target: {fileID: 4442516632743243454, guid: a35a82b670e35ac4aa3594152075595d, type: 3}
       propertyPath: m_LocalPosition.x
       value: 14.97344

--- a/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterA/OrnithopterA.cs
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterA/OrnithopterA.cs
@@ -5,6 +5,47 @@ namespace VehicleSystem.Vehicles.OrnithopterA
 {
     public class OrnithopterA : AirVehicle
     {
+        public Transform barrelPoint_A;
+        public Transform barrelPoint_B;
+        public Transform barrelTransform;
 
+        protected override void Update()
+        {
+            base.Update();
+
+            if (targetObject != null && isAttacking)
+            {
+                LookAtTarget(targetObject.transform);
+            }
+        }
+
+        protected override void FireShot()
+        {
+            base.FireShot();
+
+            if (bulletPrefab != null && currentAmmunition > 0)
+            {
+                GameObject bullet_A = Instantiate(bulletPrefab, barrelPoint_A.position, barrelPoint_A.rotation);
+                bullet_A.GetComponent<Rigidbody>().linearVelocity = barrelPoint_A.forward * bulletSpeed;
+
+                GameObject bullet_B = Instantiate(bulletPrefab, barrelPoint_B.position, barrelPoint_B.rotation);
+                bullet_B.GetComponent<Rigidbody>().linearVelocity = barrelPoint_B.forward * bulletSpeed;
+
+                currentAmmunition -= 2;
+            }
+            else if (currentAmmunition <= 0)
+            {
+                Debug.Log("Out of ammunition, reloading...");
+                ReloadAmmunition();
+            }
+        }
+
+        private void LookAtTarget(Transform target)
+        {
+            Vector3 directionToTarget = target.position - barrelTransform.position;
+            Vector3 localDirection = transform.InverseTransformDirection(directionToTarget);
+            Quaternion targetLocalRotation = Quaternion.LookRotation(localDirection);
+            barrelTransform.localRotation = Quaternion.Slerp(barrelTransform.localRotation, targetLocalRotation, Time.deltaTime * turnSpeed);
+        }
     }
 }

--- a/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterA/OrnithopterA.prefab
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterA/OrnithopterA.prefab
@@ -30,7 +30,9 @@ Transform:
   m_LocalPosition: {x: -0, y: 0.3228711, z: 1.0427506}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 4048120109068463893}
+  - {fileID: 6325185049854432032}
   m_Father: {fileID: 4442516632743243454}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &710270692257627436
@@ -453,9 +455,14 @@ MonoBehaviour:
   targetObject: {fileID: 0}
   smokeEffect: {fileID: 8772498824888722677}
   cruisingAltitude: 35
-  attackAltitude: 10
-  attackLobeRadius: 70
+  attackAltitude: 7
+  attackLobeRadius: 50
   loiterRadius: 40
+  maxBankAngle: 100
+  bankSpeed: 30
+  barrelPoint_A: {fileID: 4048120109068463893}
+  barrelPoint_B: {fileID: 6325185049854432032}
+  barrelTransform: {fileID: 4166134374202684327}
 --- !u!65 &8976528752417907667
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -564,6 +571,68 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &8147949250731462183
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6325185049854432032}
+  m_Layer: 6
+  m_Name: BarrelPoint_B
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6325185049854432032
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8147949250731462183}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.204, y: -0.072999954, z: 0.9889984}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4166134374202684327}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8377260624438740236
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4048120109068463893}
+  m_Layer: 6
+  m_Name: BarrelPoint_A
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4048120109068463893
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8377260624438740236}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.198, y: -0.073, z: 0.989}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4166134374202684327}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &2734929954258652001
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Updated OrnithopterA and TankCombat to use dual barrel points for firing, instantiating two bullets per shot and adjusting ammunition accordingly. Simplified and unified barrel transform and targeting logic. Updated prefabs and scene references to match new structure.