### PR TITLE
Refactor UI panels and update HUD styles

### DIFF
--- a/Red Strike/Assets/Scenes/SampleScene.unity
+++ b/Red Strike/Assets/Scenes/SampleScene.unity
@@ -490,6 +490,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   inputController: {fileID: 1556403732}
+  mainStationTemplate: {fileID: 9197481963319205126, guid: 7e5b2e72160062249ab83c27bd5a52e7, type: 3}
+  hangarTemplate: {fileID: 9197481963319205126, guid: 5a649d49f0f531a49a7cdedc28d5fce4, type: 3}
+  energyTowerTemplate: {fileID: 9197481963319205126, guid: 11d450df22e338a49886331ef99c2108, type: 3}
 --- !u!1 &460729958
 GameObject:
   m_ObjectHideFlags: 0

--- a/Red Strike/Assets/UISystem/EnergyTowerDetailsContent.uxml
+++ b/Red Strike/Assets/UISystem/EnergyTowerDetailsContent.uxml
@@ -1,7 +1,7 @@
 <ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
     <Style src="project://database/Assets/UISystem/GameHUDStyles.uss?fileID=7433441132597879392&amp;guid=76481a45a761bb147acf1059658d7ddd&amp;type=3#GameHUDStyles" />
-    <ui:VisualElement name="root-container" style="flex-grow: 1;">
-        <ui:VisualElement name="energy-tower-content" class="info-panel">
+    <ui:VisualElement name="root-container">
+        <ui:VisualElement name="energy-tower-content" class="dynamic-content">
             <ui:Label text="Capacity:" name="capacity-label" class="details-text" />
             <ui:Label text="Density:" name="density-label" class="details-text" />
         </ui:VisualElement>

--- a/Red Strike/Assets/UISystem/GameHUD.uxml
+++ b/Red Strike/Assets/UISystem/GameHUD.uxml
@@ -1,30 +1,36 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:engine="UnityEngine.UIElements" editor-extension-mode="False">
     <Style src="project://database/Assets/UI%20Toolkit/GameHUDStyles.uss?fileID=7433441132597879392&amp;guid=76481a45a761bb147acf1059658d7ddd&amp;type=3#GameHUDStyles" />
-    <ui:VisualElement name="root-container" style="width: 100%; height: 100%; justify-content: space-between; align-items: stretch;">
-        <ui:VisualElement name="top-bar-container" style="height: 30px; background-color: rgba(20, 20, 20, 0.9);" />
-        <ui:VisualElement name="middle-content" style="flex-grow: 1;" />
+    <ui:VisualElement name="root-container" style="width: 100%; height: 100%;">
 
+        <!-- TOP BAR -->
+        <ui:VisualElement name="top-bar-container" class="top-bar" />
+
+        <!-- SIDE PANEL (LEFT) -->
         <ui:VisualElement name="left-panel" class="side-panel">
             <ui:Button text="Main Station" name="main-station-button" class="build-button" />
             <ui:Button text="Hangar" name="hangar-button" class="build-button" />
             <ui:Button text="Energy Tower" name="energy-tower-button" class="build-button" />
         </ui:VisualElement>
 
+        <!-- BUILDING DETAILS PANEL (RIGHT) -->
         <ui:VisualElement name="building-details-panel" class="info-panel" visible="false">
             <ui:Label text="Build Type:" name="shared-build-type-label" class="details-title" />
             <ui:Label text="Health:" name="shared-health-label" class="details-text" />
 
-            <ui:VisualElement name="building-dynamic-content-container" />
+            <!-- CONTENT AREA (dynamic) -->
+            <ui:VisualElement name="building-dynamic-content-container" class="dynamic-content" />
         </ui:VisualElement>
 
+        <!-- VEHICLE DETAILS PANEL (RIGHT) -->
         <ui:VisualElement name="vehicle-details-panel" class="info-panel" visible="false">
-            <ui:Label text="Vehicle Type:" name="shared-vehicle-type-label" class="details-title" />
-            <ui:Label text="Health:" name="shared-health-label" class="details-text" />
-            <ui:Label text="Target:" name="shared-target-label" class="details-text" />
-            <ui:Label text="Fuel:" name="shared-fuel-label" class="details-text" />
-            <ui:Label text="Bullets:" name="shared-bullets-label" class="details-text" />
+            <ui:Label text="Vehicle:" name="shared-vehicle-name-label" class="details-title" />
+            <ui:Label text="Health:" name="shared-vehicle-health-label" class="details-text" />
+            <ui:Label text="Fuel:" name="shared-vehicle-fuel-label" class="details-text" />
+            <ui:Label text="Ammunition:" name="shared-vehicle-ammo-label" class="details-text" />
+            <ui:Label text="Target:" name="shared-vehicle-target-label" class="details-text" />
 
-            <ui:VisualElement name="vehicle-dynamic-content-container" />
+            <!-- CONTENT AREA (dynamic) -->
+            <ui:VisualElement name="vehicle-dynamic-content-container" class="dynamic-content" />
         </ui:VisualElement>
 
     </ui:VisualElement>

--- a/Red Strike/Assets/UISystem/GameHUDStyles.uss
+++ b/Red Strike/Assets/UISystem/GameHUDStyles.uss
@@ -1,9 +1,24 @@
+/* TOP BAR ------------------------------------------------------- */
+
+.top-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 30px;
+    background-color: rgba(20, 20, 20, 0.9);
+}
+
+/* LEFT PANEL ----------------------------------------------------- */
+
 .side-panel {
     position: absolute;
     left: 20px;
     top: 50px;
     flex-direction: column;
 }
+
+/* DETAILS PANELS (RIGHT) ---------------------------------------- */
 
 .info-panel {
     position: absolute;
@@ -12,56 +27,50 @@
     background-color: rgba(45, 45, 45, 0.85);
     padding: 15px;
     border-radius: 5px;
-    min-width: 200px;
+    min-width: 240px;
+    height: auto; 
 }
 
-.unit-panel {
-    position: absolute;
-    bottom: 20px;
-    left: 50%;
-    transform: translateX(-50%);
-    flex-direction: row;
+.dynamic-content {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top-width: 1px;
+    border-top-color: rgba(255, 255, 255, 0.2);
+    width: 100%;
 }
+
+/* BUTTONS --------------------------------------------------------- */
 
 .build-button {
-    width: 120px;
-    height: 50px;
-    background-color: rgba(60, 60, 60, 0.9);
+    width: 140px;
+    height: 45px;
+    background-color: rgba(60,60,60,0.9);
     color: white;
     border-width: 0;
-    border-radius: 3px;
+    border-radius: 4px;
     margin-bottom: 10px;
     font-size: 14px;
 }
 
-.unit-button {
-    height: 60px;
-    background-color: rgba(60, 60, 60, 0.9);
-    color: white;
-    border-width: 0;
-    border-radius: 3px;
-    margin: 0 4px;
-    font-size: 14px;
-    -unity-text-align: middle-center;
-    white-space: normal;
+.build-button:hover {
+    background-color: rgba(90, 90, 90, 0.95);
 }
 
-.unit-button--large { width: 130px; font-size: 18px; }
-.unit-button--medium { width: 100px; }
-.unit-button--small { width: 80px; font-size: 12px; }
+.build-button:active {
+    background-color: rgba(120, 120, 120, 1);
+}
 
-.build-button:hover, .unit-button:hover { background-color: rgba(90, 90, 90, 0.95); }
-.build-button:active, .unit-button:active { background-color: rgba(120, 120, 120, 1); }
+/* TEXT STYLES --------------------------------------------------- */
 
 .details-title {
     color: white;
-    font-size: 24px;
+    font-size: 20px;
     -unity-font-style: bold;
-    margin-bottom: 10px;
+    margin-bottom: 6px;
 }
 
 .details-text {
     color: rgb(220, 220, 220);
     font-size: 14px;
-    margin-bottom: 5px;
+    margin-bottom: 4px;
 }

--- a/Red Strike/Assets/UISystem/HangarDetailsContent.uxml
+++ b/Red Strike/Assets/UISystem/HangarDetailsContent.uxml
@@ -1,7 +1,7 @@
 <ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
     <Style src="project://database/Assets/UISystem/GameHUDStyles.uss?fileID=7433441132597879392&amp;guid=76481a45a761bb147acf1059658d7ddd&amp;type=3#GameHUDStyles" />
-    <ui:VisualElement name="root-container" style="flex-grow: 1;">
-        <ui:VisualElement name="hangar-content" class="info-panel">
+    <ui:VisualElement name="root-container">
+        <ui:VisualElement name="hangar-content" class="dynamic-content">
             <ui:Label text="Is Ready:" name="is-ready-label" class="details-text" />
             <ui:Label text="In production:" name="in-production-label" class="details-text" />
         </ui:VisualElement>

--- a/Red Strike/Assets/UISystem/MainStationDetailsContent.uxml
+++ b/Red Strike/Assets/UISystem/MainStationDetailsContent.uxml
@@ -1,7 +1,7 @@
 <ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
     <Style src="project://database/Assets/UISystem/GameHUDStyles.uss?fileID=7433441132597879392&amp;guid=76481a45a761bb147acf1059658d7ddd&amp;type=3#GameHUDStyles" />
-    <ui:VisualElement name="root-container" style="flex-grow: 1;">
-        <ui:VisualElement name="main-station-content" class="info-panel">
+    <ui:VisualElement name="root-container">
+        <ui:VisualElement name="main-station-content" class="dynamic-content">
             <ui:Label text="Shield:" name="shield-label" class="details-text" />
         </ui:VisualElement>
     </ui:VisualElement>


### PR DESCRIPTION
Reworked the structure and styling of building and vehicle details panels in the GameHUD. Updated UXML files to use 'dynamic-content' instead of 'info-panel' for content containers, and improved the GameHUDStyles.uss with new classes for top bar, side panel, and dynamic content. Adjusted labels and layout for clarity and consistency. Added template references in SampleScene.unity for main station, hangar, and energy tower.