### PR TITLE
Refactor team and player type handling for units

### DIFF
--- a/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunition.cs
+++ b/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunition.cs
@@ -1,13 +1,12 @@
 using UnityEngine;
+using VehicleSystem.Vehicles;
 
 namespace AmmunitionSystem.Ammunitions
 {
     public class Ammunition : MonoBehaviour
     {
         public AmmunitionSystem.Ammunition ammunitionData;
-        public VehicleSystem.Vehicles.Vehicle ownerVehicle;
-        public virtual void SetRocket(Transform targetTransform)
-        {
-        }
+        public Vehicle ownerVehicle;
+        public virtual void SetRocket(Transform targetTransform) { }
     }
 }

--- a/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicBullet/BasicBullet.cs
+++ b/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicBullet/BasicBullet.cs
@@ -1,6 +1,4 @@
 using UnityEngine;
-using VehicleSystem.Vehicles;
-using BuildingPlacement.Buildings;
 
 namespace AmmunitionSystem.Ammunitions.BasicBullet
 {
@@ -38,6 +36,5 @@ namespace AmmunitionSystem.Ammunitions.BasicBullet
 
             Destroy(gameObject);
         }
-
     }
 }

--- a/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicRocket/BasicRocket.cs
+++ b/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicRocket/BasicRocket.cs
@@ -58,8 +58,15 @@ namespace AmmunitionSystem.Ammunitions.BasicRocket
             if (ownerVehicle != null && collision.gameObject == ownerVehicle.gameObject)
                 return;
 
-            if (collision.gameObject.CompareTag("Ammunition"))
+            var unit = collision.gameObject.GetComponent<Unit.Unit>();
+            if (unit == null)
                 return;
+
+            if (unit.teamId == ownerVehicle.teamId)
+                return;
+
+            Debug.Log($"Hit unit: {collision.gameObject.name}, Damage: {ammunitionData.damage}");
+            // unit.GetComponent<HealthSystem>()?.TakeDamage(ammunitionData.damage);
 
             hasExploded = true;
 
@@ -67,12 +74,6 @@ namespace AmmunitionSystem.Ammunitions.BasicRocket
             {
                 GameObject explosionEffect = Instantiate(explosionEffectPrefab, transform.position, Quaternion.identity);
                 Destroy(explosionEffect, 2f);
-            }
-
-            if (collision.gameObject.CompareTag("Enemy"))
-            {
-                Debug.Log($"Hit enemy: {collision.gameObject.name}, Damage: {ammunitionData.damage}");
-                // örn: collision.gameObject.GetComponent<Health>()?.TakeDamage(ammunitionData.damage);
             }
 
             Destroy(gameObject);

--- a/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicTankShell/BasicTankShell.cs
+++ b/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicTankShell/BasicTankShell.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using BuildingPlacement.Buildings;
 
 namespace AmmunitionSystem.Ammunitions.Ammunitions.BasicTankShell
 {
@@ -27,8 +28,15 @@ namespace AmmunitionSystem.Ammunitions.Ammunitions.BasicTankShell
             if (ownerVehicle != null && collision.gameObject == ownerVehicle.gameObject)
                 return;
 
-            if (collision.gameObject.CompareTag("Ammunition"))
+            var unit = collision.gameObject.GetComponent<Unit.Unit>();
+            if (unit == null)
                 return;
+
+            if (unit.teamId == ownerVehicle.teamId)
+                return;
+
+            Debug.Log($"Hit unit: {collision.gameObject.name}, Damage: {ammunitionData.damage}");
+            // unit.GetComponent<HealthSystem>()?.TakeDamage(ammunitionData.damage);
 
             hasExploded = true;
 
@@ -36,12 +44,6 @@ namespace AmmunitionSystem.Ammunitions.Ammunitions.BasicTankShell
             {
                 GameObject explosionEffect = Instantiate(explosionEffectPrefab, transform.position, Quaternion.identity);
                 Destroy(explosionEffect, 2f);
-            }
-
-            if (collision.gameObject.CompareTag("Enemy"))
-            {
-                Debug.Log($"Hit enemy: {collision.gameObject.name}, Damage: {ammunitionData.damage}");
-                // örn: collision.gameObject.GetComponent<Health>()?.TakeDamage(ammunitionData.damage);
             }
 
             Destroy(gameObject);

--- a/Red Strike/Assets/BuildingPlacement/Buildings/Building.cs
+++ b/Red Strike/Assets/BuildingPlacement/Buildings/Building.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using Unit;
 
 namespace BuildingPlacement.Buildings
 {
@@ -35,11 +36,5 @@ namespace BuildingPlacement.Buildings
 
             Debug.Log($"Building {BuildingName} collided with unit: {collision.gameObject.name}");
         }
-    }
-
-    public enum PlayerType
-    {
-        Red,
-        Blue
     }
 }

--- a/Red Strike/Assets/Scenes/GameScene.unity
+++ b/Red Strike/Assets/Scenes/GameScene.unity
@@ -1057,6 +1057,10 @@ PrefabInstance:
       value: Infantry
       objectReference: {fileID: 0}
     - target: {fileID: 3693194386570448113, guid: 652e336fe8416d44694bb7c08b2b9f16, type: 3}
+      propertyPath: teamId
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3693194386570448113, guid: 652e336fe8416d44694bb7c08b2b9f16, type: 3}
       propertyPath: targetObject
       value: 
       objectReference: {fileID: 483664587}
@@ -1292,6 +1296,10 @@ PrefabInstance:
     - target: {fileID: 224654450759790032, guid: 652e336fe8416d44694bb7c08b2b9f16, type: 3}
       propertyPath: m_Name
       value: Infantry (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3693194386570448113, guid: 652e336fe8416d44694bb7c08b2b9f16, type: 3}
+      propertyPath: teamId
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 3693194386570448113, guid: 652e336fe8416d44694bb7c08b2b9f16, type: 3}
       propertyPath: targetObject

--- a/Red Strike/Assets/Unit/PlayerType.cs
+++ b/Red Strike/Assets/Unit/PlayerType.cs
@@ -1,0 +1,8 @@
+namespace Unit
+{
+    public enum PlayerType
+    {
+        Red,
+        Blue
+    }
+}

--- a/Red Strike/Assets/Unit/PlayerType.cs.meta
+++ b/Red Strike/Assets/Unit/PlayerType.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 52464538e8f8f494eb041acbfec3da2d

--- a/Red Strike/Assets/Unit/Unit.cs
+++ b/Red Strike/Assets/Unit/Unit.cs
@@ -1,4 +1,3 @@
-using BuildingPlacement.Buildings;
 using UnityEngine;
 
 namespace Unit
@@ -7,7 +6,6 @@ namespace Unit
     {
         [Header("Unit Info")]
         public int teamId;
-
         public PlayerType playerType;
     }
 }


### PR DESCRIPTION
Moved PlayerType enum to its own file in the Unit namespace and updated references accordingly. Improved collision logic for BasicRocket and BasicTankShell to use teamId for friendly fire checks. Updated GameScene to assign teamId to infantry units. Cleaned up unused usings and code in affected classes.