### PR TITLE
Implement TakeDamage for Unit, Vehicle, and Building

### DIFF
--- a/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicBullet/BasicBullet.cs
+++ b/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicBullet/BasicBullet.cs
@@ -31,8 +31,7 @@ namespace AmmunitionSystem.Ammunitions.BasicBullet
             if (unit.teamId == ownerVehicle.teamId)
                 return;
 
-            Debug.Log($"Hit unit: {collision.gameObject.name}, Damage: {ammunitionData.damage}");
-            // unit.GetComponent<HealthSystem>()?.TakeDamage(ammunitionData.damage);
+            unit.TakeDamage(ammunitionData.damage);
 
             Destroy(gameObject);
         }

--- a/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicRocket/BasicRocket.cs
+++ b/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicRocket/BasicRocket.cs
@@ -66,7 +66,7 @@ namespace AmmunitionSystem.Ammunitions.BasicRocket
                 return;
 
             Debug.Log($"Hit unit: {collision.gameObject.name}, Damage: {ammunitionData.damage}");
-            // unit.GetComponent<HealthSystem>()?.TakeDamage(ammunitionData.damage);
+            unit.TakeDamage(ammunitionData.damage);
 
             hasExploded = true;
 

--- a/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicTankShell/BasicTankShell.cs
+++ b/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicTankShell/BasicTankShell.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using BuildingPlacement.Buildings;
 
 namespace AmmunitionSystem.Ammunitions.Ammunitions.BasicTankShell
 {
@@ -36,7 +35,7 @@ namespace AmmunitionSystem.Ammunitions.Ammunitions.BasicTankShell
                 return;
 
             Debug.Log($"Hit unit: {collision.gameObject.name}, Damage: {ammunitionData.damage}");
-            // unit.GetComponent<HealthSystem>()?.TakeDamage(ammunitionData.damage);
+            unit.TakeDamage(ammunitionData.damage);
 
             hasExploded = true;
 

--- a/Red Strike/Assets/BuildingPlacement/Buildings/Building.cs
+++ b/Red Strike/Assets/BuildingPlacement/Buildings/Building.cs
@@ -25,6 +25,20 @@ namespace BuildingPlacement.Buildings
             health = maxHealth;
         }
 
+        public override void TakeDamage(float damage)
+        {
+            health -= damage;
+            health = Mathf.Max(0, health);
+
+            Debug.Log($"Building {BuildingName} took {damage} damage. Remaining health: {health}");
+
+            if (health <= 0)
+            {
+                Debug.Log($"Building {BuildingName} destroyed.");
+                Destroy(gameObject);
+            }
+        }
+
         private void OnCollisionEnter(Collision collision)
         {
             var unit = collision.gameObject.GetComponent<Unit.Unit>();

--- a/Red Strike/Assets/Scenes/GameScene.unity
+++ b/Red Strike/Assets/Scenes/GameScene.unity
@@ -635,6 +635,7 @@ GameObject:
   - component: {fileID: 460729959}
   - component: {fileID: 460729964}
   - component: {fileID: 460729963}
+  - component: {fileID: 460729965}
   m_Layer: 6
   m_Name: Sphere
   m_TagString: Enemy
@@ -762,6 +763,20 @@ MonoBehaviour:
   precomputeOutline: 0
   bakeKeys: []
   bakeValues: []
+--- !u!114 &460729965
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 460729958}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bcb4f7460ecc9104b9932edfb5089ede, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  teamId: 5
+  playerType: 0
 --- !u!1 &483664587 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 224654450759790032, guid: 652e336fe8416d44694bb7c08b2b9f16, type: 3}

--- a/Red Strike/Assets/Unit/Unit.cs
+++ b/Red Strike/Assets/Unit/Unit.cs
@@ -7,5 +7,10 @@ namespace Unit
         [Header("Unit Info")]
         public int teamId;
         public PlayerType playerType;
+
+        public virtual void TakeDamage(float damage)
+        {
+            // Implement damage logic here
+        }
     }
 }

--- a/Red Strike/Assets/VehicleSystem/Vehicles/Vehicle.cs
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/Vehicle.cs
@@ -310,5 +310,19 @@ namespace VehicleSystem.Vehicles
                 currentAmmunition_rocket = rocketAmmunitionSettings.maxAmmunition;
             }
         }
+
+        public override void TakeDamage(float damage)
+        {
+            health -= damage;
+            health = Mathf.Max(0, health);
+
+            Debug.Log($"Vehicle {vehicleData.vehicleName} took {damage} damage. Remaining health: {health}");
+
+            if (health <= 0)
+            {
+                Debug.Log($"Vehicle {vehicleData.vehicleName} destroyed.");
+                Destroy(gameObject);
+            }
+        }
     }
 }


### PR DESCRIPTION
Added virtual TakeDamage method to Unit and implemented damage handling for Vehicle and Building, including health reduction and destruction logic. Updated ammunition scripts to call TakeDamage directly on hit targets, streamlining damage application.