### PR TITLE
Refactor unit selection and add unitType to units

### DIFF
--- a/Red Strike/Assets/BuildingPlacement/Buildings/EnergyTower/EnergyTower.prefab
+++ b/Red Strike/Assets/BuildingPlacement/Buildings/EnergyTower/EnergyTower.prefab
@@ -126,11 +126,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1a6eab0dde3f71446a801665164dc283, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  teamId: 0
   playerType: 0
+  unitType: 1
   buildingData: {fileID: -4322946230525120543}
   buildEffects:
   - {fileID: 2273246402830813632}
   - {fileID: 9072490561556554335}
+  maxCapacity: 500
+  currentCapacity: 0
+  maxDensity: 3
+  rechargeRate: 10
+  isActive: 1
 --- !u!65 &5647536224997323072
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Red Strike/Assets/BuildingPlacement/Buildings/Hangar/Hangar.prefab
+++ b/Red Strike/Assets/BuildingPlacement/Buildings/Hangar/Hangar.prefab
@@ -216,7 +216,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d1b395b496c5ad441bf15c92bfc1c719, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  teamId: 0
   playerType: 1
+  unitType: 1
   buildingData: {fileID: 5840819227562748720}
   buildEffects:
   - {fileID: 1855726554393846403}

--- a/Red Strike/Assets/BuildingPlacement/Buildings/MainStation/MainStation.prefab
+++ b/Red Strike/Assets/BuildingPlacement/Buildings/MainStation/MainStation.prefab
@@ -104,13 +104,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 43fdd334c99237f47ae7f97bed928889, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  teamId: 0
   playerType: 0
+  unitType: 1
   buildingData: {fileID: 5269824642355325504}
   buildEffects:
   - {fileID: 8204242674232356029}
   - {fileID: 4710826401873965783}
   radarTransform: {fileID: 7222708778872805534}
   radarRotationSpeed: 280
+  ShieldAmount: 100
 --- !u!95 &9197393951426874775
 Animator:
   serializedVersion: 7

--- a/Red Strike/Assets/Scenes/GameScene.unity
+++ b/Red Strike/Assets/Scenes/GameScene.unity
@@ -777,6 +777,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   teamId: 5
   playerType: 0
+  unitType: 0
 --- !u!1 &483664587 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 224654450759790032, guid: 652e336fe8416d44694bb7c08b2b9f16, type: 3}
@@ -1236,6 +1237,7 @@ MonoBehaviour:
   minDistanceBetweenObjects: 25
   vehiclesHUDController: {fileID: 422005013}
   buildingHUDController: {fileID: 422005014}
+  teamId: 0
 --- !u!1 &1702380761
 GameObject:
   m_ObjectHideFlags: 0

--- a/Red Strike/Assets/Unit/PlayerType.cs
+++ b/Red Strike/Assets/Unit/PlayerType.cs
@@ -1,8 +1,0 @@
-namespace Unit
-{
-    public enum PlayerType
-    {
-        Red,
-        Blue
-    }
-}

--- a/Red Strike/Assets/Unit/PlayerType.cs.meta
+++ b/Red Strike/Assets/Unit/PlayerType.cs.meta
@@ -1,2 +1,0 @@
-fileFormatVersion: 2
-guid: 52464538e8f8f494eb041acbfec3da2d

--- a/Red Strike/Assets/Unit/Unit.cs
+++ b/Red Strike/Assets/Unit/Unit.cs
@@ -7,10 +7,14 @@ namespace Unit
         [Header("Unit Info")]
         public int teamId;
         public PlayerType playerType;
+        public UnitType unitType;
 
         public virtual void TakeDamage(float damage)
         {
             // Implement damage logic here
         }
     }
+
+    public enum PlayerType { Red, Blue }
+    public enum UnitType { Vehicle, Building }
 }


### PR DESCRIPTION
Introduces a unitType property to units and updates prefabs and scene objects to use it. Refactors InputController selection logic to use unitType and teamId for friendly/enemy checks. Removes PlayerType.cs and moves enums into Unit.cs for better encapsulation.