### PR TITLE
Add explosion effects to buildings and vehicles

### DIFF
--- a/Red Strike/Assets/BuildingPlacement/Building.cs
+++ b/Red Strike/Assets/BuildingPlacement/Building.cs
@@ -5,10 +5,14 @@ namespace BuildingPlacement
     [CreateAssetMenu(fileName = "NewBuilding", menuName = "Buildings/BuildingsDatabase")]
     public class Building : ScriptableObject
     {
+        [Header("Building Settings")]
         public string buildingName;
         public GameObject buildingPrefab;
         public int maxHealth;
         public float buildTime;
         public int maxCreatedUnits;
+
+        [Header("Effects")]
+        public ParticleSystem explosionEffect;
     }
 }

--- a/Red Strike/Assets/BuildingPlacement/Buildings/Building.cs
+++ b/Red Strike/Assets/BuildingPlacement/Buildings/Building.cs
@@ -5,7 +5,7 @@ namespace BuildingPlacement.Buildings
 {
     public class Building : Unit.Unit
     {
-        public Building buildingData;
+        public BuildingPlacement.Building buildingData;
         public ParticleSystem[] buildEffects;
 
         protected float health;
@@ -21,7 +21,7 @@ namespace BuildingPlacement.Buildings
                 main.startColor = playerType == PlayerType.Red ? Color.red : Color.blue;
             }
 
-            maxHealth = buildingData.health;
+            maxHealth = buildingData.maxHealth;
             health = maxHealth;
         }
 
@@ -35,6 +35,7 @@ namespace BuildingPlacement.Buildings
             if (health <= 0)
             {
                 Debug.Log($"Building {BuildingName} destroyed.");
+                Instantiate(buildingData.explosionEffect, transform.position, Quaternion.identity);
                 Destroy(gameObject);
             }
         }

--- a/Red Strike/Assets/BuildingPlacement/Buildings/EnergyTower/EnergyTower.asset
+++ b/Red Strike/Assets/BuildingPlacement/Buildings/EnergyTower/EnergyTower.asset
@@ -17,3 +17,4 @@ MonoBehaviour:
   maxHealth: 150
   buildTime: 3.51
   maxCreatedUnits: 3
+  explosionEffect: {fileID: 19800002, guid: 6ecf76dc4f268d340b2666896a954bcc, type: 3}

--- a/Red Strike/Assets/BuildingPlacement/Buildings/EnergyTower/EnergyTower.prefab
+++ b/Red Strike/Assets/BuildingPlacement/Buildings/EnergyTower/EnergyTower.prefab
@@ -131,7 +131,7 @@ MonoBehaviour:
   teamId: 0
   playerType: 0
   unitType: 1
-  buildingData: {fileID: -4322946230525120543}
+  buildingData: {fileID: 11400000, guid: 99f7c912324c6684c915f1110a575fbf, type: 2}
   buildEffects:
   - {fileID: 2273246402830813632}
   - {fileID: 9072490561556554335}

--- a/Red Strike/Assets/BuildingPlacement/Buildings/Hangar/Hangar.asset
+++ b/Red Strike/Assets/BuildingPlacement/Buildings/Hangar/Hangar.asset
@@ -17,3 +17,4 @@ MonoBehaviour:
   maxHealth: 300
   buildTime: 3.51
   maxCreatedUnits: 2
+  explosionEffect: {fileID: 19800002, guid: 6ecf76dc4f268d340b2666896a954bcc, type: 3}

--- a/Red Strike/Assets/BuildingPlacement/Buildings/Hangar/Hangar.prefab
+++ b/Red Strike/Assets/BuildingPlacement/Buildings/Hangar/Hangar.prefab
@@ -221,7 +221,7 @@ MonoBehaviour:
   teamId: 0
   playerType: 1
   unitType: 1
-  buildingData: {fileID: 5840819227562748720}
+  buildingData: {fileID: 11400000, guid: a20ea262914989645a27af443d4c8b0b, type: 2}
   buildEffects:
   - {fileID: 1855726554393846403}
   - {fileID: 4273443631821389091}

--- a/Red Strike/Assets/BuildingPlacement/Buildings/MainStation/MainStation.asset
+++ b/Red Strike/Assets/BuildingPlacement/Buildings/MainStation/MainStation.asset
@@ -17,3 +17,4 @@ MonoBehaviour:
   maxHealth: 500
   buildTime: 3.51
   maxCreatedUnits: 1
+  explosionEffect: {fileID: 19800002, guid: 6ecf76dc4f268d340b2666896a954bcc, type: 3}

--- a/Red Strike/Assets/BuildingPlacement/Buildings/MainStation/MainStation.prefab
+++ b/Red Strike/Assets/BuildingPlacement/Buildings/MainStation/MainStation.prefab
@@ -109,7 +109,7 @@ MonoBehaviour:
   teamId: 0
   playerType: 0
   unitType: 1
-  buildingData: {fileID: 5269824642355325504}
+  buildingData: {fileID: 11400000, guid: 25b5998dd3a37a74fbed9e8adcc609ce, type: 2}
   buildEffects:
   - {fileID: 8204242674232356029}
   - {fileID: 4710826401873965783}

--- a/Red Strike/Assets/PlanetAtmosphereSystem/CloudMaterial.mat
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/CloudMaterial.mat
@@ -41,6 +41,7 @@ Material:
     - _QueueControl: 0
     - _QueueOffset: 0
     m_Colors:
+    - _Color: {r: 0, g: 1.0177532, b: 1.5933679, a: 1}
     - _GunesYonu: {r: -1, g: 0, b: 0, a: 0}
     - _SunDirection: {r: -0, g: 0.4099231, b: -0.9121201, a: 0}
   m_BuildTextureStacks: []

--- a/Red Strike/Assets/PlanetAtmosphereSystem/CloudShader.shadergraph
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/CloudShader.shadergraph
@@ -5,6 +5,9 @@
     "m_Properties": [
         {
             "m_Id": "70977b918b5a423a8effc17b78ac0ff5"
+        },
+        {
+            "m_Id": "660b9209546f4a638204c18676149413"
         }
     ],
     "m_Keywords": [],
@@ -40,9 +43,6 @@
             "m_Id": "c0c4289691f74b248b3e99de9d04c31b"
         },
         {
-            "m_Id": "684d34cc10e143f8a306b6b739a6d30b"
-        },
-        {
             "m_Id": "f529c10b17374d5f9d17ada1d4937eb1"
         },
         {
@@ -68,6 +68,9 @@
         },
         {
             "m_Id": "8588b9ec83b84581875428555824989c"
+        },
+        {
+            "m_Id": "7b0b70d0f9ac49c6a1ad55d6682b375a"
         }
     ],
     "m_GroupDatas": [],
@@ -104,7 +107,7 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "684d34cc10e143f8a306b6b739a6d30b"
+                    "m_Id": "7b0b70d0f9ac49c6a1ad55d6682b375a"
                 },
                 "m_SlotId": 0
             },
@@ -830,47 +833,33 @@
 }
 
 {
-    "m_SGVersion": 1,
-    "m_Type": "UnityEditor.ShaderGraph.ColorNode",
-    "m_ObjectId": "684d34cc10e143f8a306b6b739a6d30b",
-    "m_Group": {
-        "m_Id": ""
+    "m_SGVersion": 3,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.ColorShaderProperty",
+    "m_ObjectId": "660b9209546f4a638204c18676149413",
+    "m_Guid": {
+        "m_GuidSerialized": "45836369-fe66-47de-9952-34ac9667a2a4"
     },
     "m_Name": "Color",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -826.0,
-            "y": 13.000000953674317,
-            "width": 207.99993896484376,
-            "height": 124.99993896484375
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "87fcd2bbbde5451c9f32e250ca7d986e"
-        }
-    ],
-    "synonyms": [
-        "rgba"
-    ],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Color",
+    "m_DefaultReferenceName": "_Color",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0,
+        "a": 1.0
     },
-    "m_Color": {
-        "color": {
-            "r": 1.0,
-            "g": 1.0,
-            "b": 1.0,
-            "a": 1.0
-        },
-        "mode": 1
-    }
+    "isMainColor": false,
+    "m_ColorMode": 1
 }
 
 {
@@ -1023,6 +1012,42 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "7b0b70d0f9ac49c6a1ad55d6682b375a",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -723.0,
+            "y": 41.0,
+            "width": 105.0,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "b97c732bb9c2499e8b0a892ad8925979"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "660b9209546f4a638204c18676149413"
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.SaturateNode",
     "m_ObjectId": "8540043c5f7d4df9b6edfc063e15a57d",
     "m_Group": {
@@ -1141,31 +1166,6 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
-    "m_ObjectId": "87fcd2bbbde5451c9f32e250ca7d986e",
-    "m_Id": 0,
-    "m_DisplayName": "Out",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_Labels": []
 }
 
 {
@@ -1390,6 +1390,31 @@
     "m_DefaultValue": {
         "x": 1.0,
         "y": 1.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "b97c732bb9c2499e8b0a892ad8925979",
+    "m_Id": 0,
+    "m_DisplayName": "Color",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     },
     "m_Labels": []
 }
@@ -1707,6 +1732,9 @@
     "m_ChildObjectList": [
         {
             "m_Id": "70977b918b5a423a8effc17b78ac0ff5"
+        },
+        {
+            "m_Id": "660b9209546f4a638204c18676149413"
         }
     ]
 }

--- a/Red Strike/Assets/Scenes/BluePlanetArea.unity
+++ b/Red Strike/Assets/Scenes/BluePlanetArea.unity
@@ -226,7 +226,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: -0.6953463, y: -0.54836357, z: -0.28765324, w: 0.36475548}
   m_LocalPosition: {x: 507, y: -0.000061035156, z: 503}
-  m_LocalScale: {x: 1462.1101, y: 1462.1101, z: 1462.1101}
+  m_LocalScale: {x: 3000, y: 3000, z: 3000}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 999300466}
@@ -621,7 +621,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: -0.6953463, y: -0.54836357, z: -0.28765324, w: 0.36475548}
   m_LocalPosition: {x: 507, y: -0.000061035156, z: 502.99988}
-  m_LocalScale: {x: 1396.8, y: 1396.8, z: 1396.8}
+  m_LocalScale: {x: 2919, y: 2919, z: 2919}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 999300466}
@@ -707,7 +707,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: -0.6953463, y: -0.54836357, z: -0.28765324, w: 0.36475548}
   m_LocalPosition: {x: 507, y: -0.000061035156, z: 502.99988}
-  m_LocalScale: {x: 1440, y: 1440, z: 1440}
+  m_LocalScale: {x: 2821, y: 2821, z: 2821}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 999300466}
@@ -858,7 +858,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 499, y: 137, z: 502}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 999300466}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -5662,63 +5662,6 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
     vectorLabel1_3: W
---- !u!1001 &1769253995
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2490931318532185407, guid: 4b5c1b1b00d4a804aaaa616ab88ccd5f, type: 3}
-      propertyPath: m_Name
-      value: Hangar
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996551972402132310, guid: 4b5c1b1b00d4a804aaaa616ab88ccd5f, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 273.18265
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996551972402132310, guid: 4b5c1b1b00d4a804aaaa616ab88ccd5f, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.000015258789
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996551972402132310, guid: 4b5c1b1b00d4a804aaaa616ab88ccd5f, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 2.567276
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996551972402132310, guid: 4b5c1b1b00d4a804aaaa616ab88ccd5f, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996551972402132310, guid: 4b5c1b1b00d4a804aaaa616ab88ccd5f, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996551972402132310, guid: 4b5c1b1b00d4a804aaaa616ab88ccd5f, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996551972402132310, guid: 4b5c1b1b00d4a804aaaa616ab88ccd5f, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996551972402132310, guid: 4b5c1b1b00d4a804aaaa616ab88ccd5f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996551972402132310, guid: 4b5c1b1b00d4a804aaaa616ab88ccd5f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996551972402132310, guid: 4b5c1b1b00d4a804aaaa616ab88ccd5f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4b5c1b1b00d4a804aaaa616ab88ccd5f, type: 3}
 --- !u!1 &1936849618
 GameObject:
   m_ObjectHideFlags: 0
@@ -5945,9 +5888,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 70d5e1bc8a892c841afaa940cb019eb1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mainStationTemplate: {fileID: 9197481963319205126, guid: 7e5b2e72160062249ab83c27bd5a52e7, type: 3}
-  hangarTemplate: {fileID: 9197481963319205126, guid: 5a649d49f0f531a49a7cdedc28d5fce4, type: 3}
-  energyTowerTemplate: {fileID: 9197481963319205126, guid: 11d450df22e338a49886331ef99c2108, type: 3}
 --- !u!114 &2126698101
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5971,4 +5911,3 @@ SceneRoots:
   - {fileID: 2126698098}
   - {fileID: 1454141292}
   - {fileID: 387184704}
-  - {fileID: 1769253995}

--- a/Red Strike/Assets/VehicleSystem/Vehicle.cs
+++ b/Red Strike/Assets/VehicleSystem/Vehicle.cs
@@ -20,6 +20,9 @@ namespace VehicleSystem
         public float fuelCapacity;
         public float fuelConsumptionRate;
 
+        [Header("Effects")]
+        public ParticleSystem explosionEffect;
+
         [Header("Ammunition Settings")]
         public List<VehicleAmmunition> ammunitionSettings = new List<VehicleAmmunition>();
     }

--- a/Red Strike/Assets/VehicleSystem/Vehicles/Infantry/Infantry.asset
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/Infantry/Infantry.asset
@@ -22,6 +22,7 @@ MonoBehaviour:
   maxHealth: 100
   fuelCapacity: 100
   fuelConsumptionRate: 0.8
+  explosionEffect: {fileID: 19800002, guid: 3364c97de68d3a147af572d1c71c6455, type: 3}
   ammunitionSettings:
   - isEnabled: 1
     ammunitionType: 0

--- a/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterA/OrnithopterA.asset
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterA/OrnithopterA.asset
@@ -22,6 +22,7 @@ MonoBehaviour:
   maxHealth: 100
   fuelCapacity: 100
   fuelConsumptionRate: 5
+  explosionEffect: {fileID: 19800006, guid: e0609132424a24844b1d53ad3d704fd9, type: 3}
   ammunitionSettings:
   - isEnabled: 1
     ammunitionType: 0

--- a/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterB/OrnithopterB.asset
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterB/OrnithopterB.asset
@@ -22,6 +22,7 @@ MonoBehaviour:
   maxHealth: 100
   fuelCapacity: 100
   fuelConsumptionRate: 0.7
+  explosionEffect: {fileID: 19800006, guid: e0609132424a24844b1d53ad3d704fd9, type: 3}
   ammunitionSettings:
   - isEnabled: 1
     ammunitionType: 0

--- a/Red Strike/Assets/VehicleSystem/Vehicles/Quad/Quad.asset
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/Quad/Quad.asset
@@ -22,6 +22,7 @@ MonoBehaviour:
   maxHealth: 100
   fuelCapacity: 100
   fuelConsumptionRate: 0.7
+  explosionEffect: {fileID: 19800002, guid: 3364c97de68d3a147af572d1c71c6455, type: 3}
   ammunitionSettings:
   - isEnabled: 1
     ammunitionType: 0

--- a/Red Strike/Assets/VehicleSystem/Vehicles/TankCombat/TankCombat.asset
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/TankCombat/TankCombat.asset
@@ -22,6 +22,7 @@ MonoBehaviour:
   maxHealth: 100
   fuelCapacity: 100
   fuelConsumptionRate: 0.9
+  explosionEffect: {fileID: 19800002, guid: 3364c97de68d3a147af572d1c71c6455, type: 3}
   ammunitionSettings:
   - isEnabled: 1
     ammunitionType: 0

--- a/Red Strike/Assets/VehicleSystem/Vehicles/TankHeavyA/TankHeavyA.asset
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/TankHeavyA/TankHeavyA.asset
@@ -22,6 +22,7 @@ MonoBehaviour:
   maxHealth: 100
   fuelCapacity: 100
   fuelConsumptionRate: 0.7
+  explosionEffect: {fileID: 19800002, guid: 3364c97de68d3a147af572d1c71c6455, type: 3}
   ammunitionSettings:
   - isEnabled: 1
     ammunitionType: 0

--- a/Red Strike/Assets/VehicleSystem/Vehicles/TankHeavyB/TankHeavyB.asset
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/TankHeavyB/TankHeavyB.asset
@@ -22,6 +22,7 @@ MonoBehaviour:
   maxHealth: 100
   fuelCapacity: 100
   fuelConsumptionRate: 0.7
+  explosionEffect: {fileID: 19800002, guid: 3364c97de68d3a147af572d1c71c6455, type: 3}
   ammunitionSettings:
   - isEnabled: 1
     ammunitionType: 0

--- a/Red Strike/Assets/VehicleSystem/Vehicles/Trike/Trike.asset
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/Trike/Trike.asset
@@ -22,6 +22,7 @@ MonoBehaviour:
   maxHealth: 100
   fuelCapacity: 100
   fuelConsumptionRate: 0.7
+  explosionEffect: {fileID: 19800002, guid: 3364c97de68d3a147af572d1c71c6455, type: 3}
   ammunitionSettings:
   - isEnabled: 1
     ammunitionType: 0

--- a/Red Strike/Assets/VehicleSystem/Vehicles/Vehicle.cs
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/Vehicle.cs
@@ -321,6 +321,7 @@ namespace VehicleSystem.Vehicles
             if (health <= 0)
             {
                 Debug.Log($"Vehicle {vehicleData.vehicleName} destroyed.");
+                Instantiate(vehicleData.explosionEffect, transform.position, Quaternion.identity);
                 Destroy(gameObject);
             }
         }


### PR DESCRIPTION
Introduced an explosionEffect ParticleSystem field to both Building and Vehicle ScriptableObjects and updated their destruction logic to instantiate the effect upon destruction. Updated relevant asset and prefab references to support the new effect. Also made minor adjustments to the BluePlanetArea scene and improved the cloud shader with a new color property.