### PR TITLE
Add sun movement and day cycle to atmosphere system

### DIFF
--- a/Red Strike/Assets/PlanetAtmosphereSystem/AtmosphereMaterial.mat
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/AtmosphereMaterial.mat
@@ -47,7 +47,7 @@ Material:
     - _GunesYonu: {r: -0.91, g: 0.4, b: 3.24, a: 0}
     - _RenkUzak: {r: 0, g: 0.10166844, b: 2.152374, a: 1}
     - _RenkYakin: {r: 0, g: 5.670685, b: 8, a: 1}
-    - _SunDirection: {r: -0, g: 0.4099231, b: -0.9121201, a: 0}
+    - _SunDirection: {r: 0.17096215, g: 0.1752097, b: -0.96957386, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
 --- !u!114 &1522106816477559216

--- a/Red Strike/Assets/PlanetAtmosphereSystem/CloudMaterial.mat
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/CloudMaterial.mat
@@ -43,7 +43,7 @@ Material:
     m_Colors:
     - _Color: {r: 0, g: 1.0177532, b: 1.5933679, a: 1}
     - _GunesYonu: {r: -1, g: 0, b: 0, a: 0}
-    - _SunDirection: {r: -0, g: 0.4099231, b: -0.9121201, a: 0}
+    - _SunDirection: {r: 0.17096215, g: 0.1752097, b: -0.96957386, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
 --- !u!114 &8499732345945835446

--- a/Red Strike/Assets/PlanetAtmosphereSystem/FogMaterial.mat
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/FogMaterial.mat
@@ -54,6 +54,6 @@ Material:
     - _QueueControl: 0
     - _QueueOffset: 0
     m_Colors:
-    - _SunDirection: {r: -0, g: 0.4099231, b: -0.9121201, a: 0}
+    - _SunDirection: {r: 0.17096215, g: 0.1752097, b: -0.96957386, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1

--- a/Red Strike/Assets/PlanetAtmosphereSystem/PlanetAtmosphereSystem.cs
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/PlanetAtmosphereSystem.cs
@@ -4,7 +4,12 @@ namespace PlanetAtmosphereSystem
 {
     public class PlanetAtmosphereSystem : MonoBehaviour
     {
+        [Header("Sun Settings")]
         public Light sunLight;
+        public float dayDurationInSeconds = 120f;
+        private float timeElapsed = 0f;
+
+        [Header("Materials")]
         public Material atmosphereMaterial;
         public Material cloudMaterial;
         public Material fogMaterial;
@@ -17,7 +22,13 @@ namespace PlanetAtmosphereSystem
                 atmosphereMaterial.SetVector("_SunDirection", sunDirection);
                 cloudMaterial.SetVector("_SunDirection", sunDirection);
                 fogMaterial.SetVector("_SunDirection", sunDirection);
+
+                timeElapsed += Time.deltaTime;
+                float normalizedTime = (timeElapsed % dayDurationInSeconds) / dayDurationInSeconds;
+
+                float sunAngle = normalizedTime * 360f - 90f;
+                sunLight.transform.rotation = Quaternion.Euler(new Vector3(sunAngle, 170f, 0f));
             }
-        } 
+        }
     }
 }

--- a/Red Strike/Assets/Scenes/BluePlanetArea.unity
+++ b/Red Strike/Assets/Scenes/BluePlanetArea.unity
@@ -344,7 +344,7 @@ Camera:
     width: 1
     height: 1
   near clip plane: 0.01
-  far clip plane: 1200
+  far clip plane: 500000
   field of view: 60
   orthographic: 0
   orthographic size: 5
@@ -401,7 +401,7 @@ MonoBehaviour:
     m_Bits: 1
   m_VolumeTrigger: {fileID: 0}
   m_VolumeFrameworkUpdateModeOption: 2
-  m_RenderPostProcessing: 0
+  m_RenderPostProcessing: 1
   m_Antialiasing: 0
   m_AntialiasingQuality: 2
   m_StopNaN: 0
@@ -5673,6 +5673,7 @@ GameObject:
   - component: {fileID: 1936849620}
   - component: {fileID: 1936849619}
   - component: {fileID: 1936849621}
+  - component: {fileID: 1936849622}
   m_Layer: 0
   m_Name: SunLight
   m_TagString: Untagged
@@ -5783,6 +5784,21 @@ MonoBehaviour:
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
   m_SoftShadowQuality: 0
+--- !u!114 &1936849622
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1936849618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 902d3dd2f52a3ac4ab39f0e3bb13d3df, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sunLight: {fileID: 0}
+  dayDurationInSeconds: 120
+  timeElapsed: 0
 --- !u!1 &2126698095
 GameObject:
   m_ObjectHideFlags: 0
@@ -5873,6 +5889,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   sunLight: {fileID: 1936849619}
+  dayDurationInSeconds: 60
   atmosphereMaterial: {fileID: 2100000, guid: 2408ec61631a3e24db680f86b5b150a7, type: 2}
   cloudMaterial: {fileID: 2100000, guid: 452202a9af21f504594d57e7b894652a, type: 2}
   fogMaterial: {fileID: 2100000, guid: cb5b62743c9506845aa26111364535f4, type: 2}


### PR DESCRIPTION
Introduces a dayDurationInSeconds parameter and animates the sun's rotation to simulate a day-night cycle in PlanetAtmosphereSystem.cs. Updates materials to use the new sun direction, modifies scene settings for improved rendering, and adds the system component to the BluePlanetArea scene.