### PR TITLE
Refactor teamId to networked property and improve building placement

### DIFF
--- a/Red Strike/Assets/BuildingPlacement/Buildings/Building.cs
+++ b/Red Strike/Assets/BuildingPlacement/Buildings/Building.cs
@@ -15,18 +15,14 @@ namespace BuildingPlacement.Buildings
 
         private void Start()
         {
-            foreach (ParticleSystem effect in buildEffects)
-            {
-                var main = effect.main;
-                main.startColor = playerType == PlayerType.Red ? Color.red : Color.blue;
-            }
-
             maxHealth = buildingData.maxHealth;
             health = maxHealth;
         }
 
         public override void TakeDamage(float damage)
         {
+            if (!Object.HasStateAuthority) return;
+            
             health -= damage;
             health = Mathf.Max(0, health);
 
@@ -36,7 +32,7 @@ namespace BuildingPlacement.Buildings
             {
                 Debug.Log($"Building {BuildingName} destroyed.");
                 Instantiate(buildingData.explosionEffect, transform.position, Quaternion.identity);
-                Destroy(gameObject);
+                Runner.Despawn(Object);
             }
         }
 

--- a/Red Strike/Assets/NetworkingSystem/CommanderData.cs
+++ b/Red Strike/Assets/NetworkingSystem/CommanderData.cs
@@ -1,35 +1,93 @@
 using UnityEngine;
 using Fusion;
+using System.Linq;
+using InputController;
 
 namespace NetworkingSystem
 {
     public class CommanderData : NetworkBehaviour
     {
-        [Networked] public int PlayerMoney { get; set; }
-        [Networked] public int PlayerTeamID { get; set; }
+        public static CommanderData LocalCommander;
+
+        [Networked]
+        public int PlayerTeamID { get; set; }
+
+        private ChangeDetector _changeDetector;
 
         public override void Spawned()
         {
+            _changeDetector = GetChangeDetector(ChangeDetector.Source.SimulationState);
+
             if (Object.HasInputAuthority)
             {
-                Debug.Log($"Benim Komutan objem yüklendi! Takımım: {PlayerTeamID}");
-
-                if (InputController.InputController.Instance != null)
-                {
-                    InputController.InputController.Instance.teamId = PlayerTeamID;
-
-                    Debug.Log("InputController Takım ID güncellendi: " + PlayerTeamID);
-                }
-                else
-                {
-                    Debug.LogError("Sahne InputController bulunamadı!");
-                }
-
-                if (Runner.IsServer) PlayerMoney = 2000;
+                Debug.Log($"Benim Komutan objem yüklendi! (Spawned)");
+                LocalCommander = this;
             }
             else
             {
-                Debug.Log($"Rakibin Komutan objesi (Takım: {PlayerTeamID}) yüklendi.");
+                Debug.Log($"Rakibin Komutan objesi yüklendi.");
+            }
+        }
+
+        public override void Render()
+        {
+            foreach (var change in _changeDetector.DetectChanges(this))
+            {
+                if (change == nameof(PlayerTeamID))
+                {
+                    OnTeamIdChanged();
+                }
+            }
+
+            if (Object.HasInputAuthority)
+            {
+                if (InputController.InputController.Instance != null)
+                {
+                    if (PlayerTeamID != 0 && InputController.InputController.Instance.teamId != PlayerTeamID)
+                    {
+                        InputController.InputController.Instance.teamId = PlayerTeamID;
+                        Debug.Log($"<color=yellow>ZORLA EŞİTLEME:</color> InputController ID'si {PlayerTeamID} olarak düzeltildi.");
+                    }
+                }
+            }
+        }
+
+        private void OnTeamIdChanged()
+        {
+            if (Object.HasInputAuthority)
+            {
+                if (InputController.InputController.Instance != null && PlayerTeamID != 0)
+                {
+                    InputController.InputController.Instance.teamId = PlayerTeamID;
+                    Debug.Log($"<color=green>GÜNCELLEME:</color> Takım ID'si {PlayerTeamID} olarak değişti ve ayarlandı!");
+                }
+            }
+        }
+
+        [Rpc(RpcSources.InputAuthority, RpcTargets.StateAuthority)]
+        public void RPC_SpawnBuilding(string buildingName, Vector3 position)
+        {
+            Debug.Log($"Server: {Object.InputAuthority} oyuncusu {buildingName} kurmak istiyor.");
+
+            if (InputController.InputController.Instance == null) return;
+
+            var database = InputController.InputController.Instance.buildingsDatabase;
+            var buildingData = database.buildings.FirstOrDefault(b => b.buildingName == buildingName);
+
+            if (buildingData != null && buildingData.buildingPrefab != null)
+            {
+                NetworkObject spawnedObj = Runner.Spawn(buildingData.buildingPrefab, position, Quaternion.identity, Object.InputAuthority);
+
+                var unitScript = spawnedObj.GetComponent<Unit.Unit>();
+                if (unitScript != null)
+                {
+                    unitScript.teamId = PlayerTeamID;
+                    Debug.Log($"Bina kuruldu ({buildingName}). Takım ID: {PlayerTeamID} atandı.");
+                }
+            }
+            else
+            {
+                Debug.LogError($"Server: {buildingName} prefabı bulunamadı!");
             }
         }
     }

--- a/Red Strike/Assets/Resources/EnergyTower.prefab
+++ b/Red Strike/Assets/Resources/EnergyTower.prefab
@@ -107,7 +107,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1a6eab0dde3f71446a801665164dc283, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  teamId: 0
+  _teamId: 0
   playerType: 0
   unitType: 1
   buildingData: {fileID: 11400000, guid: 99f7c912324c6684c915f1110a575fbf, type: 2}
@@ -188,6 +188,7 @@ MonoBehaviour:
   Flags: 262145
   NestedObjects: []
   NetworkedBehaviours:
+  - {fileID: -4322946230525120543}
   - {fileID: 1945554365250611277}
   ForceRemoteRenderTimeframe: 0
 --- !u!114 &1945554365250611277

--- a/Red Strike/Assets/Resources/Hangar.prefab
+++ b/Red Strike/Assets/Resources/Hangar.prefab
@@ -197,7 +197,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d1b395b496c5ad441bf15c92bfc1c719, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  teamId: 0
+  _teamId: 0
   playerType: 1
   unitType: 1
   buildingData: {fileID: 11400000, guid: a20ea262914989645a27af443d4c8b0b, type: 2}
@@ -276,6 +276,7 @@ MonoBehaviour:
   Flags: 262145
   NestedObjects: []
   NetworkedBehaviours:
+  - {fileID: 5840819227562748720}
   - {fileID: 1041543833642334784}
   ForceRemoteRenderTimeframe: 0
 --- !u!114 &1041543833642334784

--- a/Red Strike/Assets/Resources/MainStation.prefab
+++ b/Red Strike/Assets/Resources/MainStation.prefab
@@ -107,7 +107,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 43fdd334c99237f47ae7f97bed928889, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  teamId: 0
+  _teamId: 0
   playerType: 0
   unitType: 1
   buildingData: {fileID: 11400000, guid: 25b5998dd3a37a74fbed9e8adcc609ce, type: 2}
@@ -186,6 +186,7 @@ MonoBehaviour:
   Flags: 262145
   NestedObjects: []
   NetworkedBehaviours:
+  - {fileID: 5269824642355325504}
   - {fileID: 3522928540239067126}
   ForceRemoteRenderTimeframe: 0
 --- !u!114 &3522928540239067126
@@ -381,7 +382,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6813416509558619124, guid: 3b7f2c753d435d647a80f1f047a113e3, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -469,6 +470,10 @@ PrefabInstance:
     - target: {fileID: 985483039366664255, guid: f91edac4d13fc4343ba96bb6a843ad05, type: 3}
       propertyPath: m_Layer
       value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 985483039366664255, guid: f91edac4d13fc4343ba96bb6a843ad05, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1110556030845387871, guid: f91edac4d13fc4343ba96bb6a843ad05, type: 3}
       propertyPath: ShapeModule.angle

--- a/Red Strike/Assets/Unit/Unit.cs
+++ b/Red Strike/Assets/Unit/Unit.cs
@@ -5,11 +5,10 @@ namespace Unit
 {
     [RequireComponent(typeof(NetworkObject))]
     [RequireComponent(typeof(NetworkTransform))]
-    public class Unit : MonoBehaviour
+    public class Unit : NetworkBehaviour
     {
         [Header("Unit Info")]
-        public int teamId;
-        public PlayerType playerType;
+        [Networked] public int teamId { get; set; }
         public UnitType unitType;
 
         public virtual void TakeDamage(float damage)

--- a/Red Strike/Assets/VehicleSystem/Vehicles/Infantry/Infantry.prefab
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/Infantry/Infantry.prefab
@@ -217,7 +217,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 03c758935046a67489542a05c26f0445, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  teamId: 0
+  _teamId: 0
   playerType: 0
   unitType: 0
   vehicleData: {fileID: 11400000, guid: b049ed01ebeaf174e82c98ba0beb4efa, type: 2}
@@ -316,6 +316,7 @@ MonoBehaviour:
   Flags: 262145
   NestedObjects: []
   NetworkedBehaviours:
+  - {fileID: 3693194386570448113}
   - {fileID: 3648919941748004774}
   ForceRemoteRenderTimeframe: 0
 --- !u!114 &3648919941748004774

--- a/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterA/OrnithopterA.prefab
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterA/OrnithopterA.prefab
@@ -20546,7 +20546,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c0d511396c012094da7050bbf90ea6e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  teamId: 0
+  _teamId: 0
   playerType: 0
   unitType: 0
   vehicleData: {fileID: 11400000, guid: 5d7c72c6670df4e408f287de587d7085, type: 2}
@@ -20662,6 +20662,7 @@ MonoBehaviour:
   Flags: 262145
   NestedObjects: []
   NetworkedBehaviours:
+  - {fileID: -2782345837604721076}
   - {fileID: 6704487169046173774}
   ForceRemoteRenderTimeframe: 0
 --- !u!114 &6704487169046173774

--- a/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterB/OrnithopterB.prefab
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterB/OrnithopterB.prefab
@@ -35110,7 +35110,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dba6f2c3499a5e940899e97e54715f47, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  teamId: 0
+  _teamId: 0
   playerType: 0
   unitType: 0
   vehicleData: {fileID: 11400000, guid: e188ef8daa801334c82cd841cb6d6fcc, type: 2}
@@ -35231,6 +35231,7 @@ MonoBehaviour:
   Flags: 262145
   NestedObjects: []
   NetworkedBehaviours:
+  - {fileID: 9172212943852637613}
   - {fileID: 2694785929477182230}
   ForceRemoteRenderTimeframe: 0
 --- !u!114 &2694785929477182230

--- a/Red Strike/Assets/VehicleSystem/Vehicles/Quad/Quad.prefab
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/Quad/Quad.prefab
@@ -24714,7 +24714,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c46abc4e03cd62e47a3915024872b2a7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  teamId: 0
+  _teamId: 0
   playerType: 0
   unitType: 0
   vehicleData: {fileID: 11400000, guid: ce97c2204a6a39643bf1b985564c1deb, type: 2}
@@ -24816,6 +24816,7 @@ MonoBehaviour:
   Flags: 262145
   NestedObjects: []
   NetworkedBehaviours:
+  - {fileID: 5052494845539565231}
   - {fileID: 4578676548635405671}
   ForceRemoteRenderTimeframe: 0
 --- !u!114 &4578676548635405671

--- a/Red Strike/Assets/VehicleSystem/Vehicles/TankCombat/TankCombat.prefab
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/TankCombat/TankCombat.prefab
@@ -29234,7 +29234,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bf2ece4367702df40b58ebd200083e17, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  teamId: 0
+  _teamId: 0
   playerType: 0
   unitType: 0
   vehicleData: {fileID: 11400000, guid: 1f1539dd50fac9945990afd398d5ff90, type: 2}
@@ -29312,6 +29312,7 @@ MonoBehaviour:
   Flags: 262145
   NestedObjects: []
   NetworkedBehaviours:
+  - {fileID: 7143828502900667078}
   - {fileID: 7331351960429707841}
   ForceRemoteRenderTimeframe: 0
 --- !u!114 &7331351960429707841

--- a/Red Strike/Assets/VehicleSystem/Vehicles/TankHeavyA/TankHeavyA.prefab
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/TankHeavyA/TankHeavyA.prefab
@@ -29162,7 +29162,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 85efa6e2bb0f3474a95e59186e5c9199, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  teamId: 0
+  _teamId: 0
   playerType: 0
   unitType: 0
   vehicleData: {fileID: 11400000, guid: 0d1e17da9fb2af947b26c9a568ced7d5, type: 2}
@@ -29240,6 +29240,7 @@ MonoBehaviour:
   Flags: 262145
   NestedObjects: []
   NetworkedBehaviours:
+  - {fileID: 3156332687679153054}
   - {fileID: 2034773910388246365}
   ForceRemoteRenderTimeframe: 0
 --- !u!114 &2034773910388246365

--- a/Red Strike/Assets/VehicleSystem/Vehicles/TankHeavyB/TankHeavyB.prefab
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/TankHeavyB/TankHeavyB.prefab
@@ -34162,7 +34162,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a1537c636a236fc42af5e0eaa5de9861, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  teamId: 0
+  _teamId: 0
   playerType: 0
   unitType: 0
   vehicleData: {fileID: 11400000, guid: 2401c75b324e39040b0b2d2edbfe5039, type: 2}
@@ -34283,6 +34283,7 @@ MonoBehaviour:
   Flags: 262145
   NestedObjects: []
   NetworkedBehaviours:
+  - {fileID: 9160367188802437689}
   - {fileID: 7989778151804778632}
   ForceRemoteRenderTimeframe: 0
 --- !u!114 &7989778151804778632

--- a/Red Strike/Assets/VehicleSystem/Vehicles/Trike/Trike.prefab
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/Trike/Trike.prefab
@@ -9974,7 +9974,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e698bb0d0e53815468b9f02e5c16ff4e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  teamId: 0
+  _teamId: 0
   playerType: 0
   unitType: 0
   vehicleData: {fileID: 11400000, guid: 6b721204d4c46a24db720117c7fd198c, type: 2}
@@ -10072,6 +10072,7 @@ MonoBehaviour:
   Flags: 262145
   NestedObjects: []
   NetworkedBehaviours:
+  - {fileID: 19923418697428257}
   - {fileID: 2575185209052483038}
   ForceRemoteRenderTimeframe: 0
 --- !u!114 &2575185209052483038


### PR DESCRIPTION
Converted Unit.teamId to a [Networked] property and updated all prefabs to use the new backing field. Refactored InputController to use networked building placement via CommanderData.RPC_SpawnBuilding, enforcing main base placement rules and improving selection/deselection logic. Updated CommanderData to synchronize team IDs and handle networked building spawning. Prefabs updated to include Unit as a NetworkBehaviour and to reference the correct networked fields.