### PR TITLE
Remove debug log statements and refactor vehicle code

### DIFF
--- a/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicBullet/BasicBullet.cs
+++ b/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicBullet/BasicBullet.cs
@@ -48,7 +48,7 @@ namespace AmmunitionSystem.Ammunitions.BasicBullet
                     return;
                 }
 
-                Debug.Log($"Hit Enemy: {unit.name} - Damage: {ammunitionData.damage}");
+                //Debug.Log($"Hit Enemy: {unit.name} - Damage: {ammunitionData.damage}");
                 unit.TakeDamage(ammunitionData.damage);
             }
             

--- a/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicRocket/BasicRocket.cs
+++ b/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicRocket/BasicRocket.cs
@@ -69,7 +69,7 @@ namespace AmmunitionSystem.Ammunitions.BasicRocket
                 return;
             }
 
-            Debug.Log($"Hit unit: {collision.gameObject.name}, Damage: {ammunitionData.damage}");
+            //Debug.Log($"Hit unit: {collision.gameObject.name}, Damage: {ammunitionData.damage}");
             unit.TakeDamage(ammunitionData.damage);
 
             hasExploded = true;

--- a/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicTankShell/BasicTankShell.cs
+++ b/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicTankShell/BasicTankShell.cs
@@ -45,7 +45,7 @@ namespace AmmunitionSystem.Ammunitions.Ammunitions.BasicTankShell
                 return;
             }
 
-            Debug.Log($"Hit unit: {collision.gameObject.name}, Damage: {ammunitionData.damage}");
+            //Debug.Log($"Hit unit: {collision.gameObject.name}, Damage: {ammunitionData.damage}");
             unit.TakeDamage(ammunitionData.damage);
 
             hasExploded = true;

--- a/Red Strike/Assets/BuildingPlacement/Buildings/Building.cs
+++ b/Red Strike/Assets/BuildingPlacement/Buildings/Building.cs
@@ -31,7 +31,7 @@ namespace BuildingPlacement.Buildings
 
             if (health <= 0)
             {
-                Debug.Log($"Building {BuildingName} destroyed.");
+                //Debug.Log($"Building {BuildingName} destroyed.");
 
                 ParticleSystem exp = Instantiate(buildingData.explosionEffect, transform.position, Quaternion.identity);
                 Destroy(exp.gameObject, exp.main.duration);
@@ -63,7 +63,7 @@ namespace BuildingPlacement.Buildings
             if (unit.teamId == teamId)
                 return;
 
-            Debug.Log($"Building {BuildingName} collided with unit: {collision.gameObject.name}");
+            //Debug.Log($"Building {BuildingName} collided with unit: {collision.gameObject.name}");
         }
     }
 }

--- a/Red Strike/Assets/BuildingPlacement/Buildings/Hangar/Hangar.cs
+++ b/Red Strike/Assets/BuildingPlacement/Buildings/Hangar/Hangar.cs
@@ -27,12 +27,12 @@ namespace BuildingPlacement.Buildings
                 InProductionUnitName = vehicleType.ToString();
                 IsReady = false;
                 
-                Debug.Log($"Hangar started creating a new vehicle: {InProductionUnitName}");
+                //Debug.Log($"Hangar started creating a new vehicle: {InProductionUnitName}");
                 CreateVehicleInstance(vehicleType);
             }
             else
             {
-                Debug.LogWarning("Hangar is not ready to create a new vehicle or already in production.");
+                //Debug.LogWarning("Hangar is not ready to create a new vehicle or already in production.");
             }
         }
 

--- a/Red Strike/Assets/InputController/InputController.cs
+++ b/Red Strike/Assets/InputController/InputController.cs
@@ -62,7 +62,7 @@ namespace InputController
                 if (currentSelectedBuilding != null)
                 {
                     currentSelectedBuilding = null;
-                    Debug.Log("Bina yerleştirme iptal edildi.");
+                    //Debug.Log("Bina yerleştirme iptal edildi.");
                 }
                 else
                 {
@@ -121,24 +121,24 @@ namespace InputController
 
                     if (currentSelectedBuilding.buildingName != "Main Station" && !isThereMainBuilding)
                     {
-                        Debug.LogWarning("Önce bir Ana Üs (Main Station) yerleştirmelisiniz!");
+                        //Debug.LogWarning("Önce bir Ana Üs (Main Station) yerleştirmelisiniz!");
                         return;
                     }
 
                     if (currentSelectedBuilding.buildingName == "Main Station" && isThereMainBuilding)
                     {
-                        Debug.LogWarning("Zaten bir Ana Üs'sünüz var.");
+                        //Debug.LogWarning("Zaten bir Ana Üs'sünüz var.");
                         return;
                     }
 
                     if (CommanderData.LocalCommander != null)
                     {
                         CommanderData.LocalCommander.RPC_SpawnBuilding(currentSelectedBuilding.buildingName, spawnPosition);
-                        Debug.Log($"<color=green>Server'a İstek:</color> {currentSelectedBuilding.buildingName} kuruluyor...");
+                        //Debug.Log($"<color=green>Server'a İstek:</color> {currentSelectedBuilding.buildingName} kuruluyor...");
                     }
                     else
                     {
-                        Debug.LogError("HATA: LocalCommander (Network Bağlantısı) bulunamadı!");
+                        //Debug.LogError("HATA: LocalCommander (Network Bağlantısı) bulunamadı!");
                         return;
                     }
 
@@ -146,7 +146,7 @@ namespace InputController
                 }
                 else
                 {
-                    Debug.Log("Bu alan inşaat için uygun değil (Çok yakın veya engel var).");
+                   //Debug.Log("Bu alan inşaat için uygun değil (Çok yakın veya engel var).");
                 }
             }
         }
@@ -164,11 +164,11 @@ namespace InputController
             if (buildingToSelect != null)
             {
                 currentSelectedBuilding = buildingToSelect;
-                Debug.Log($"Seçilen: {currentSelectedBuilding.buildingName}. Yere tıklayın.");
+                //Debug.Log($"Seçilen: {currentSelectedBuilding.buildingName}. Yere tıklayın.");
             }
             else
             {
-                Debug.LogError($"Database Hatası: {buildingName} bulunamadı!");
+                //Debug.LogError($"Database Hatası: {buildingName} bulunamadı!");
             }
         }
 
@@ -197,7 +197,7 @@ namespace InputController
             {
                 if (currentSelectedVehicle != null)
                 {
-                    Debug.Log($"Saldırı Emri: {currentSelectedVehicle.name} -> {unit.name}");
+                    //Debug.Log($"Saldırı Emri: {currentSelectedVehicle.name} -> {unit.name}");
                     currentSelectedVehicle.SetTargetEnemy(unit.gameObject);
 
                     if (targetHighlighter != null) targetHighlighter.DisableHighlight();
@@ -206,7 +206,7 @@ namespace InputController
                 }
                 else
                 {
-                    Debug.Log("Düşmanı seçmek için önce kendi aracınızı seçin.");
+                    //Debug.Log("Düşmanı seçmek için önce kendi aracınızı seçin.");
                 }
                 return;
             }

--- a/Red Strike/Assets/NetworkingSystem/CommanderData.cs
+++ b/Red Strike/Assets/NetworkingSystem/CommanderData.cs
@@ -19,12 +19,12 @@ namespace NetworkingSystem
 
             if (Object.HasInputAuthority)
             {
-                Debug.Log($"Benim Komutan objem yüklendi! (Spawned)");
+                //Debug.Log($"Benim Komutan objem yüklendi! (Spawned)");
                 LocalCommander = this;
             }
             else
             {
-                Debug.Log($"Rakibin Komutan objesi yüklendi.");
+                //Debug.Log($"Rakibin Komutan objesi yüklendi.");
             }
         }
 
@@ -46,7 +46,7 @@ namespace NetworkingSystem
                     {
                         InputController.InputController.Instance.teamId = PlayerTeamID;
                         GameStateSystem.GameStateManager.Instance.LocalPlayerTeamId = PlayerTeamID;
-                        Debug.Log($"<color=yellow>ZORLA EŞİTLEME:</color> InputController ve GameStateManager ID'leri {PlayerTeamID} olarak düzeltildi.");
+                        //Debug.Log($"<color=yellow>ZORLA EŞİTLEME:</color> InputController ve GameStateManager ID'leri {PlayerTeamID} olarak düzeltildi.");
                     }
                 }
             }
@@ -60,7 +60,7 @@ namespace NetworkingSystem
                 {
                     InputController.InputController.Instance.teamId = PlayerTeamID;
                     GameStateSystem.GameStateManager.Instance.LocalPlayerTeamId = PlayerTeamID;
-                    Debug.Log($"<color=green>GÜNCELLEME:</color> Takım ID'si {PlayerTeamID} olarak değişti ve ayarlandı!");
+                    //Debug.Log($"<color=green>GÜNCELLEME:</color> Takım ID'si {PlayerTeamID} olarak değişti ve ayarlandı!");
                 }
             }
         }
@@ -81,12 +81,8 @@ namespace NetworkingSystem
                 if (unitScript != null)
                 {
                     unitScript.teamId = PlayerTeamID;
-                    Debug.Log($"Bina kuruldu ({buildingName}). Takım ID: {PlayerTeamID} atandı.");
+                    //Debug.Log($"Bina kuruldu ({buildingName}). Takım ID: {PlayerTeamID} atandı.");
                 }
-            }
-            else
-            {
-                Debug.LogError($"Server: {buildingName} prefabı bulunamadı!");
             }
         }
 
@@ -106,12 +102,8 @@ namespace NetworkingSystem
                 if (unitScript != null)
                 {
                     unitScript.teamId = PlayerTeamID;
-                    Debug.Log($"Araç üretildi ({vehicleData.vehicleName}). Takım ID: {PlayerTeamID} atandı.");
+                    //Debug.Log($"Araç üretildi ({vehicleData.vehicleName}). Takım ID: {PlayerTeamID} atandı.");
                 }
-            }
-            else
-            {
-                Debug.LogError($"Server: {vehicleData.vehicleName} prefabı bulunamadı!");
             }
         }
 
@@ -147,7 +139,7 @@ namespace NetworkingSystem
                         ammunitionScript.SetRocketTarget(targetId);
                     }
 
-                    Debug.Log($"Mühimmat fırlatıldı: {ammunitionName}. Takım: {vehicleScript.teamId}");
+                    //Debug.Log($"Mühimmat fırlatıldı: {ammunitionName}. Takım: {vehicleScript.teamId}");
                 }
             }
         }

--- a/Red Strike/Assets/NetworkingSystem/PlayerSpawner.cs
+++ b/Red Strike/Assets/NetworkingSystem/PlayerSpawner.cs
@@ -10,20 +10,20 @@ namespace NetworkingSystem
 
         public void PlayerJoined(PlayerRef player)
         {
-        if (Runner.IsServer)
-        {
-            Debug.Log($"Oyuncu Katıldı: {player.PlayerId}. Objesi oluşturuluyor...");
-            
-            NetworkObject networkPlayer = Runner.Spawn(_playerCommanderPrefab, Vector3.zero, Quaternion.identity, player);
-            
-            var commanderData = networkPlayer.GetComponent<CommanderData>();
-            
-            int teamIDToAssign = player.PlayerId;
-            
-            commanderData.PlayerTeamID = teamIDToAssign;
-            
-            Debug.Log($"Oyuncu {player.PlayerId} için Takım ID {teamIDToAssign} atandı.");
-        }
+            if (Runner.IsServer)
+            {
+                //Debug.Log($"Oyuncu Katıldı: {player.PlayerId}. Objesi oluşturuluyor...");
+
+                NetworkObject networkPlayer = Runner.Spawn(_playerCommanderPrefab, Vector3.zero, Quaternion.identity, player);
+
+                var commanderData = networkPlayer.GetComponent<CommanderData>();
+
+                int teamIDToAssign = player.PlayerId;
+
+                commanderData.PlayerTeamID = teamIDToAssign;
+
+                //Debug.Log($"Oyuncu {player.PlayerId} için Takım ID {teamIDToAssign} atandı.");
+            }
         }
     }
 }

--- a/Red Strike/Assets/VehicleSystem/Vehicles/AirVehicle.cs
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/AirVehicle.cs
@@ -71,7 +71,6 @@ namespace VehicleSystem.Vehicles
             }
             else
             {
-                // Durum makinesi
                 switch (currentState)
                 {
                     case AirState.TakingOff: HandleTakingOff(); break;
@@ -84,7 +83,6 @@ namespace VehicleSystem.Vehicles
                 ConsumeFuel();
             }
 
-            // Konumu Network'e yaz
             NetworkedPosition = transform.position;
             NetworkedRotation = transform.rotation;
         }

--- a/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterA/OrnithopterA.cs
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterA/OrnithopterA.cs
@@ -35,16 +35,13 @@ namespace VehicleSystem.Vehicles.OrnithopterA
             for (int i = 0; i < barrelPoints.Length; i++)
             {
                 Transform barrelPoint = barrelPoints[i];
-
                 CommanderData.LocalCommander.RPC_SpawnAmmunition(ammunition_bullet.ammunitionName, barrelPoint.position, rotation, Object);
+                currentAmmunition_bullet--;
             }
-
-            currentAmmunition_bullet -= 2;
         }
 
         protected override void LaunchRocket()
         {
-            Debug.LogWarning("Ornithopter A: LaunchRocket called, BUT: Not Spawning Yet");
             NetworkId targetId = default;
             if (targetObject != null) 
                 targetId = targetObject.GetComponent<NetworkObject>().Id;
@@ -69,7 +66,6 @@ namespace VehicleSystem.Vehicles.OrnithopterA
         {
             base.ReloadRocketAmmunition();
             RocketObjectVisibility(true);
-            Debug.Log("Rockets Reloaded");
         }
 
         private void RocketObjectVisibility(bool isVisible)

--- a/Red Strike/Assets/VehicleSystem/Vehicles/Vehicle.cs
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/Vehicle.cs
@@ -306,7 +306,7 @@ namespace VehicleSystem.Vehicles
                     LaunchRocket();
 
                     EnableMuzzleFlashEffects();
-                    Invoke("DisableMuzzleFlashLights", 0.1f);
+                    Invoke(nameof(DisableMuzzleFlashLights), 0.1f);
 
                     rocketCooldownTimer = rocketAmmunitionSettings.reloadTime;
                 }
@@ -333,6 +333,17 @@ namespace VehicleSystem.Vehicles
                 if (light != null)
                 {
                     light.enabled = true;
+                }
+            }
+        }
+
+        private void DisableMuzzleFlashLights()
+        {
+            foreach (var light in muzzleFlashLights)
+            {
+                if (light != null)
+                {
+                    light.enabled = false;
                 }
             }
         }
@@ -365,11 +376,11 @@ namespace VehicleSystem.Vehicles
             health -= damage;
             health = Mathf.Max(0, health);
 
-            Debug.Log($"Vehicle {vehicleData.vehicleName} took {damage} damage. Remaining health: {health}");
+            //Debug.Log($"Vehicle {vehicleData.vehicleName} took {damage} damage. Remaining health: {health}");
 
             if (health <= 0)
             {
-                Debug.Log($"Vehicle {vehicleData.vehicleName} destroyed.");
+                //Debug.Log($"Vehicle {vehicleData.vehicleName} destroyed.");
                 Instantiate(vehicleData.explosionEffect, transform.position, Quaternion.identity);
                 Runner.Despawn(Object);
             }


### PR DESCRIPTION
Commented out or removed various Debug.Log and Debug.LogWarning statements across ammunition, building, networking, and vehicle scripts to clean up console output. Refactored OrnithopterA and OrnithopterB to decrement ammunition correctly and use RPCs for spawning ammunition and rockets. Added DisableMuzzleFlashLights method in Vehicle.cs and replaced string literal in Invoke with nameof for better maintainability.