### PR TITLE
Refactor unit count tracking to use NetworkDictionary

### DIFF
--- a/Red Strike/Assets/PlanetAtmosphereSystem/AtmosphereMaterial.mat
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/AtmosphereMaterial.mat
@@ -47,7 +47,7 @@ Material:
     - _GunesYonu: {r: -0.91, g: 0.4, b: 3.24, a: 0}
     - _RenkUzak: {r: 0, g: 0.10166844, b: 2.152374, a: 1}
     - _RenkYakin: {r: 0, g: 5.670685, b: 8, a: 1}
-    - _SunDirection: {r: 0.17330775, g: 0.062598675, b: -0.9828763, a: 0}
+    - _SunDirection: {r: 0.053725094, g: 0.9509352, b: -0.30468985, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
 --- !u!114 &1522106816477559216

--- a/Red Strike/Assets/PlanetAtmosphereSystem/CloudMaterial.mat
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/CloudMaterial.mat
@@ -43,7 +43,7 @@ Material:
     m_Colors:
     - _Color: {r: 0, g: 3.8274493, b: 5.992155, a: 1}
     - _GunesYonu: {r: -1, g: 0, b: 0, a: 0}
-    - _SunDirection: {r: 0.17330775, g: 0.062598675, b: -0.9828763, a: 0}
+    - _SunDirection: {r: 0.053725094, g: 0.9509352, b: -0.30468985, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
 --- !u!114 &8499732345945835446

--- a/Red Strike/Assets/PlanetAtmosphereSystem/FogMaterial.mat
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/FogMaterial.mat
@@ -54,6 +54,6 @@ Material:
     - _QueueControl: 0
     - _QueueOffset: 0
     m_Colors:
-    - _SunDirection: {r: 0.17330775, g: 0.062598675, b: -0.9828763, a: 0}
+    - _SunDirection: {r: 0.053725094, g: 0.9509352, b: -0.30468985, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1


### PR DESCRIPTION
Replaced the local additions dictionary with a networked UnitCounts dictionary for synchronized unit tracking across clients. Added methods for reporting unit construction and destruction, updating UI accordingly, and improved RPC handling for unit count changes. Also updated _SunDirection in atmosphere, cloud, and fog material files.