### PR TITLE
Add camera shake and fade transition to main menu

### DIFF
--- a/Red Strike/Assets/CameraSystem/CinemachineCamera_Main Noise Profile.asset
+++ b/Red Strike/Assets/CameraSystem/CinemachineCamera_Main Noise Profile.asset
@@ -1,0 +1,40 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b7f59e54f2bfd184b9dd451a678d089b, type: 3}
+  m_Name: CinemachineCamera_Main Noise Profile
+  m_EditorClassIdentifier: 
+  PositionNoise:
+  - X:
+      Frequency: 0.5
+      Amplitude: 0.5
+      Constant: 0
+    Y:
+      Frequency: 0
+      Amplitude: 0
+      Constant: 0
+    Z:
+      Frequency: 0
+      Amplitude: 0
+      Constant: 0
+  - X:
+      Frequency: 15
+      Amplitude: 0.03
+      Constant: 0
+    Y:
+      Frequency: 0
+      Amplitude: 0
+      Constant: 0
+    Z:
+      Frequency: 0
+      Amplitude: 0
+      Constant: 0
+  OrientationNoise: []

--- a/Red Strike/Assets/CameraSystem/CinemachineCamera_Main Noise Profile.asset.meta
+++ b/Red Strike/Assets/CameraSystem/CinemachineCamera_Main Noise Profile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6de90b0da335151449f2f71f61322685
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Red Strike/Assets/NetworkingSystem/GameBootstrap.cs
+++ b/Red Strike/Assets/NetworkingSystem/GameBootstrap.cs
@@ -3,6 +3,7 @@ using Fusion;
 using Fusion.Sockets;
 using System.Collections.Generic;
 using System;
+using System.Threading.Tasks;
 
 namespace NetworkingSystem
 {
@@ -20,6 +21,8 @@ namespace NetworkingSystem
 
         private NetworkRunner _runner;
 
+        public Func<Task> OnGameStarting;
+
         private void Awake()
         {
             if (Instance == null)
@@ -33,7 +36,27 @@ namespace NetworkingSystem
             }
         }
 
-        public async void StartGame(GameMode mode, string sessionName)
+        public async void StartHost(string sessionName)
+        {
+            await StartSequenceAndGame(GameMode.Host, sessionName);
+        }
+
+        public async void StartClient(string sessionName)
+        {
+            await StartSequenceAndGame(GameMode.Client, sessionName);
+        }
+
+        private async Task StartSequenceAndGame(GameMode mode, string sessionName)
+        {
+            if (OnGameStarting != null)
+            {
+                await OnGameStarting.Invoke();
+            }
+
+            await StartGame(mode, sessionName);
+        }
+
+        private async Task StartGame(GameMode mode, string sessionName)
         {
             if (_runner != null) Destroy(_runner.gameObject);
 
@@ -57,10 +80,7 @@ namespace NetworkingSystem
 
         public void OnPlayerJoined(NetworkRunner runner, PlayerRef player)
         {
-            if (runner.IsServer)
-            {
-                runner.Spawn(playerDataPrefab, Vector3.zero, Quaternion.identity, player);
-            }
+            if (runner.IsServer) runner.Spawn(playerDataPrefab, Vector3.zero, Quaternion.identity, player);
         }
 
         public void OnPlayerLeft(NetworkRunner runner, PlayerRef player) { }

--- a/Red Strike/Assets/PlanetAtmosphereSystem/AtmosphereMaterial.mat
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/AtmosphereMaterial.mat
@@ -47,7 +47,7 @@ Material:
     - _GunesYonu: {r: -0.91, g: 0.4, b: 3.24, a: 0}
     - _RenkUzak: {r: 0, g: 0.10166844, b: 2.152374, a: 1}
     - _RenkYakin: {r: 0, g: 5.670685, b: 8, a: 1}
-    - _SunDirection: {r: 0.11393173, g: -0.7546686, b: -0.64613837, a: 0}
+    - _SunDirection: {r: -0.091949426, g: -0.8255108, b: 0.5568458, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
 --- !u!114 &1522106816477559216

--- a/Red Strike/Assets/PlanetAtmosphereSystem/CloudMaterial.mat
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/CloudMaterial.mat
@@ -43,7 +43,7 @@ Material:
     m_Colors:
     - _Color: {r: 0, g: 3.8274493, b: 5.992155, a: 1}
     - _GunesYonu: {r: -1, g: 0, b: 0, a: 0}
-    - _SunDirection: {r: 0.11393173, g: -0.7546686, b: -0.64613837, a: 0}
+    - _SunDirection: {r: -0.091949426, g: -0.8255108, b: 0.5568458, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
 --- !u!114 &8499732345945835446

--- a/Red Strike/Assets/PlanetAtmosphereSystem/FogMaterial.mat
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/FogMaterial.mat
@@ -54,6 +54,6 @@ Material:
     - _QueueControl: 0
     - _QueueOffset: 0
     m_Colors:
-    - _SunDirection: {r: 0.11393173, g: -0.7546686, b: -0.64613837, a: 0}
+    - _SunDirection: {r: -0.091949426, g: -0.8255108, b: 0.5568458, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1

--- a/Red Strike/Assets/Scenes/Menu.unity
+++ b/Red Strike/Assets/Scenes/Menu.unity
@@ -371,6 +371,7 @@ GameObject:
   - component: {fileID: 656923635}
   - component: {fileID: 656923634}
   - component: {fileID: 656923636}
+  - component: {fileID: 656923637}
   m_Layer: 0
   m_Name: CinemachineCamera_Main
   m_TagString: Untagged
@@ -465,6 +466,23 @@ MonoBehaviour:
     Time: 1
     Smoothing: 30
     IgnoreY: 0
+--- !u!114 &656923637
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 656923633}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 68bb026fafb42b14791938953eaace77, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NoiseProfile: {fileID: 11400000, guid: 6de90b0da335151449f2f71f61322685, type: 2}
+  PivotOffset: {x: 0, y: 0, z: 0}
+  AmplitudeGain: 1
+  FrequencyGain: 1
+  m_NoiseOffsets: {x: 421.75458, y: -900.8506, z: 117.34094}
 --- !u!1 &995665647
 GameObject:
   m_ObjectHideFlags: 0
@@ -799,8 +817,42 @@ MonoBehaviour:
   cinemachineCamera_Credits: {fileID: 312053529}
   spaceShip: {fileID: 2738940240077496202}
   shipDuration: 5
+  shipMaxShake: 3
   shipStartPosition: {x: 2.24, y: -0.6, z: -19}
   targetPosition: {x: 2.24, y: -0.6, z: -9.72}
+  shipCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 2
+      outSlope: 2
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 0.50163484
+      value: 0.39272237
+      inSlope: 0.025015866
+      outSlope: 0.025015866
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.35976583
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1.0041504
+      value: 0.0000076293945
+      inSlope: -1.6002946
+      outSlope: -1.6002946
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.124341875
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
   settings: {fileID: 11400000, guid: e041f970da61a87429a66823e0614072, type: 2}
 --- !u!4 &1693417822
 Transform:

--- a/Red Strike/Assets/UISystem/GameHUD.uxml
+++ b/Red Strike/Assets/UISystem/GameHUD.uxml
@@ -48,7 +48,7 @@
         </ui:VisualElement>
 
         <!-- 4. TAM EKRAN KAPLAMALAR (Grid dışı, en üstte) -->
-        <ui:Instance template="OverlayPanels" name="OverlayInstance" />
+        <ui:Instance template="OverlayPanels" name="OverlayInstance" picking-mode="Ignore" style="position: absolute; width: 100%; height: 100%; left: 0; top: 0;" />
         <ui:VisualElement name="fade-panel" class="fade-panel" style="display: none;" />
 
     </ui:VisualElement>

--- a/Red Strike/Assets/UISystem/MainMenuLayout.uxml
+++ b/Red Strike/Assets/UISystem/MainMenuLayout.uxml
@@ -22,7 +22,7 @@
         
         <ui:Instance template="LobbyPanel" name="LobbyInstance" picking-mode="Ignore" style="width: 100%; height: 100%; position: absolute; left: 0; top: 0;" />
         
-        <ui:VisualElement name="fade-panel" style="position: absolute; width: 100%; height: 100%; background-color: black; display: none;" />
+        <ui:VisualElement name="fade-panel" class="fade-panel" style="display: none;" />
     
     </ui:VisualElement>
 

--- a/Red Strike/Assets/UISystem/Styles/HUDLayouts.uss
+++ b/Red Strike/Assets/UISystem/Styles/HUDLayouts.uss
@@ -23,18 +23,16 @@
 
 /* --- ORTA BÖLÜM (MAIN BODY) --- */
 .main-content-area {
-    flex-grow: 1; /* Ekranın kalanını kapla */
+    flex-grow: 1;
     display: flex;
     flex-direction: row;
     padding: 20px;
-    /* align-items: flex-start;  <-- BU SATIR SİLİNDİ. Artık sütunlar boydan boya uzayacak. */
 }
 
 /* SOL SÜTUN (İnşaat Paneli) */
 .column-left {
     width: 220px;
     flex-shrink: 0;
-    /* Yatayda Sola, Dikeyde Yukarı Yasla */
     align-items: flex-start;
     justify-content: flex-start; 
 }
@@ -42,7 +40,6 @@
 /* ORTA SÜTUN (Deployment Monitor) */
 .column-center {
     flex-grow: 1;
-    /* Hem Yatayda Hem Dikeyde TAM ORTALA */
     align-items: center;     
     justify-content: center; 
 }
@@ -51,7 +48,6 @@
 .column-right {
     width: 300px;
     flex-shrink: 0;
-    /* Yatayda Sağa, Dikeyde Yukarı Yasla */
     align-items: flex-end; 
     justify-content: flex-start; 
 }

--- a/Red Strike/Assets/UISystem/Styles/HUDVSOverlays.uss
+++ b/Red Strike/Assets/UISystem/Styles/HUDVSOverlays.uss
@@ -1,11 +1,8 @@
 .vs-panel {
-    /* Flexbox içinde serbest akış */
     position: relative; 
     
     width: 600px; 
-    height: 100%; /* Footer yüksekliğini (80px) tam doldur */
-    
-    /* Olası hizalama hatalarını önlemek için margin auto */
+    height: 100%;
     margin-left: auto;
     margin-right: auto;
     margin-bottom: 0;
@@ -13,8 +10,7 @@
     background-color: rgba(0, 5, 10, 0.98);
     border-top-width: 2px;
     border-top-color: var(--primary-cyan);
-    
-    /* Alt kenarlığı kaldır (Ekranın bitimiyle birleşsin) */
+
     border-bottom-width: 0;
     
     display: flex;
@@ -57,10 +53,16 @@
 /* Overlay'ler (Absolute kalmalı) */
 .overlay-panel {
     position: absolute;
-    left: 0; top: 0; right: 0; bottom: 0;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
     background-color: rgba(0, 0, 0, 0.9);
-    align-items: center; justify-content: center;
-    z-index: 9999;
+    z-index: 2000; 
 }
 .victory-title { color: #00FF88; font-size: 50px; }
 .overlay-title { color: var(--danger-red); font-size: 50px; }

--- a/Red Strike/Assets/UISystem/Styles/HUDVariables.uss
+++ b/Red Strike/Assets/UISystem/Styles/HUDVariables.uss
@@ -15,8 +15,7 @@ Label {
 .root-interface {
     width: 100%;
     height: 100%;
-    /* Ekranı Dikey (Yukarıdan Aşağı) diziyoruz */
     display: flex;
     flex-direction: column;
-    justify-content: space-between; /* Üstü tepeye, altı dibe it */
+    justify-content: space-between;
 }

--- a/Red Strike/Assets/UISystem/Styles/MenuComponents.uss
+++ b/Red Strike/Assets/UISystem/Styles/MenuComponents.uss
@@ -34,7 +34,7 @@
     height: 100%;
     padding-left: 20px;
     padding-right: 20px;
-    background-color: rgba(0,0,0,0); /* Şeffaf */
+    background-color: rgba(0,0,0,0);
     border-width: 0;
     color: #888;
     font-size: 16px;
@@ -90,7 +90,6 @@
     background-color: var(--danger-red); 
 }
 
-/* --- INPUTS --- */
 .sci-fi-input {
     width: 300px;
     background-color: rgba(0,0,0,0.5);
@@ -98,7 +97,6 @@
     color: white;
 }
 
-/* Unity'nin kendi input alt elemanlarını düzeltmek için */
 .sci-fi-input > .unity-base-text-field__input {
     background-color: transparent;
     color: white;
@@ -112,34 +110,21 @@
     top: 0; 
     right: 0; 
     bottom: 0;
-    
-    /* Arkadaki menüyü hafif karartıp odağı buraya çekiyoruz */
     background-color: rgba(0, 0, 0, 0.85);
-    
-    /* Paneli tam ortaya hizala */
     display: flex;
     align-items: center;
     justify-content: center;
-    
-    z-index: 5000; /* En üstte durması için */
+    z-index: 5000;
 }
 
-/* --- LOGIN KUTUSU --- */
 .login-panel {
     width: 450px;
     padding: 40px;
-    
-    /* Temaya uygun koyu lacivert arka plan */
     background-color: var(--panel-bg);
-    
-    /* Neon Çerçeve */
     border-width: 2px;
     border-color: var(--primary-cyan);
     border-radius: 10px;
-    
-    /* Hafif Parlama Efekti */
     box-shadow: 0 0 20px rgba(0, 255, 255, 0.15);
-    
     align-items: center;
     display: flex;
     flex-direction: column;
@@ -170,9 +155,8 @@
     font-size: 18px;
 }
 
-/* Unity'nin varsayılan beyaz input alanını temaya uyduruyoruz */
 .username-field > .unity-base-text-field__input {
-    background-color: rgba(0, 0, 0, 0.5); /* Yarı saydam siyah */
+    background-color: rgba(0, 0, 0, 0.5);
     border-width: 1px;
     border-color: var(--secondary-blue);
     border-radius: 5px;
@@ -181,7 +165,6 @@
     padding: 10px;
 }
 
-/* Input alanına tıklandığında (Focus) */
 .username-field > .unity-base-text-field__input:focus {
     border-color: var(--primary-cyan);
     background-color: rgba(0, 255, 255, 0.05);
@@ -189,12 +172,11 @@
 
 /* --- SUBMIT BUTONU --- */
 .submit-btn {
-    width: 100%; /* Panelin genişliğini doldur */
+    width: 100%;
     height: 50px;
     font-size: 20px;
-    margin-left: 0; /* Action-btn'den gelen margin'i sıfırla */
+    margin-left: 0;
     
-    /* Onaylama olduğu için Yeşil tonları */
     background-color: rgba(0, 180, 0, 0.6);
     border-color: #00FF00;
     color: white;
@@ -210,4 +192,17 @@
 .submit-btn:active {
     background-color: rgba(0, 150, 0, 1);
     scale: 0.98;
+}
+
+.fade-panel {
+    position: absolute;
+    left: 0; top: 0;
+    right: 0; bottom: 0;
+    background-color: rgb(0, 0, 0);
+    opacity: 0;
+    picking-mode: ignore;
+    transition-property: opacity;
+    transition-duration: 4s;
+    transition-timing-function: ease-in-out;
+    display: flex;
 }

--- a/Red Strike/Assets/UISystem/Styles/MenuLayouts.uss
+++ b/Red Strike/Assets/UISystem/Styles/MenuLayouts.uss
@@ -4,22 +4,16 @@
     bottom: 50px;
     right: 50px;
     width: 400px;
-    
-    /* İçerik hizalaması */
     display: flex;
     flex-direction: column;
-    justify-content: flex-end; /* İçeriği aşağı it */
+    justify-content: flex-end;
     
     background-color: rgba(0, 0, 0, 0.8);
     border-left-width: 4px;
     border-left-color: var(--primary-cyan);
     padding: 30px;
-    
-    /* Dekoratif Köşeler */
     border-top-right-radius: 20px;
     border-bottom-left-radius: 20px;
-    
-    /* Gölge */
     box-shadow: -5px 5px 10px rgba(0,0,0,0.5);
 }
 
@@ -50,8 +44,8 @@
     background-color: var(--panel-bg);
     border-width: 2px;
     border-color: var(--primary-cyan);
-    border-top-width: 6px; /* Üst kısım daha kalın */
-    padding: 0; /* İçeriği biz yöneteceğiz */
+    border-top-width: 6px;
+    padding: 0;
     display: flex;
     flex-direction: column;
 }

--- a/Red Strike/Assets/UISystem/Styles/MenuVariables.uss
+++ b/Red Strike/Assets/UISystem/Styles/MenuVariables.uss
@@ -6,7 +6,6 @@
     --overlay-bg: rgba(0, 0, 0, 0.8);
 }
 
-/* Tüm yazılar varsayılan beyaz */
 Label {
     color: white;
     -unity-font-style: bold;
@@ -17,7 +16,5 @@ Label {
     height: 100%;
     position: absolute;
     left: 0; top: 0;
-    
-    /* DÜZELTME: Siyah rengi kaldırdık, şeffaf yaptık */
     background-color: rgba(0, 0, 0, 0); 
 }

--- a/Red Strike/Assets/UISystem/Templates/DeploymentMonitor.uxml
+++ b/Red Strike/Assets/UISystem/Templates/DeploymentMonitor.uxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ui:UXML xmlns:ui="UnityEngine.UIElements">
-    <ui:VisualElement name="deployment-panel" class="deployment-panel" style="display: flex;">
+    <ui:VisualElement name="deployment-panel" class="deployment-panel" style="display: none;">
         <ui:VisualElement class="deployment-header-container">
             <ui:Label text="GLOBAL DEPLOYMENT MONITOR" class="deployment-main-title" />
             <ui:Button text="ESC" name="deployment-close-button" class="deployment-close-button" />

--- a/Red Strike/Assets/UserSystem/AvatarImages/Avatar1.png.meta
+++ b/Red Strike/Assets/UserSystem/AvatarImages/Avatar1.png.meta
@@ -49,7 +49,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 100
-  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteBorder: {x: 0, y: 446, z: 0, w: 426}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -114,7 +114,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 0
+    internalID: 1537655665
     vertices: []
     indices: 
     edges: []

--- a/Red Strike/Assets/VehicleUI/Icons/ArrowTag.png.meta
+++ b/Red Strike/Assets/VehicleUI/Icons/ArrowTag.png.meta
@@ -49,7 +49,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 100
-  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteBorder: {x: 0, y: 112, z: 0, w: 112}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -93,6 +93,19 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites: []
@@ -101,7 +114,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 0
+    internalID: 1537655665
     vertices: []
     indices: 
     edges: []


### PR DESCRIPTION
Introduces a Cinemachine noise profile and camera shake effect during the spaceship launch sequence in the main menu. Adds a fade panel and transition animation to the UI for smoother scene changes. Refactors networking game start logic to support pre-game sequences. Updates material sun direction values and various UI/UX style improvements.