### PR TITLE
Refactor ammunition damage and update vehicle stats

### DIFF
--- a/Red Strike/Assets/AmmunitionSystem/Ammunition.cs
+++ b/Red Strike/Assets/AmmunitionSystem/Ammunition.cs
@@ -8,7 +8,6 @@ namespace AmmunitionSystem
         [Header("Ammunition Properties")]
         public AmmunitionType ammunitionType;
         public string ammunitionName;
-        public float damage;
         public float speed;
         public float range;
         public float lifetime;

--- a/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunition.cs
+++ b/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunition.cs
@@ -12,6 +12,8 @@ namespace AmmunitionSystem.Ammunitions
         [Networked] public int OwnerTeamId { get; set; } = -1;
         [Networked] public NetworkId OwnerVehicleId { get; set; }
 
+        public float damage;
+
         public virtual void SetRocketTarget(NetworkId targetId) { }
     }
 }

--- a/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicBullet/BasicBullet.cs
+++ b/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicBullet/BasicBullet.cs
@@ -50,7 +50,7 @@ namespace AmmunitionSystem.Ammunitions.BasicBullet
                 }
 
                 //Debug.Log($"Hit Enemy: {unit.name} - Damage: {ammunitionData.damage}");
-                unit.TakeDamage(ammunitionData.damage);
+                unit.TakeDamage(damage);
             }
             
             DespawnBullet();

--- a/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicRocket/BasicRocket.cs
+++ b/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicRocket/BasicRocket.cs
@@ -70,7 +70,7 @@ namespace AmmunitionSystem.Ammunitions.BasicRocket
             }
 
             //Debug.Log($"Hit unit: {collision.gameObject.name}, Damage: {ammunitionData.damage}");
-            unit.TakeDamage(ammunitionData.damage);
+            unit.TakeDamage(damage);
 
             hasExploded = true;
             CommanderData.LocalCommander.RPC_SpawnExplosionEffect(transform.position);

--- a/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicTankShell/BasicTankShell.cs
+++ b/Red Strike/Assets/AmmunitionSystem/Ammunitions/Ammunitions/BasicTankShell/BasicTankShell.cs
@@ -46,7 +46,7 @@ namespace AmmunitionSystem.Ammunitions.Ammunitions.BasicTankShell
             }
 
             //Debug.Log($"Hit unit: {collision.gameObject.name}, Damage: {ammunitionData.damage}");
-            unit.TakeDamage(ammunitionData.damage);
+            unit.TakeDamage(damage);
 
             hasExploded = true;
 

--- a/Red Strike/Assets/BuildingPlacement/Buildings/EnergyTower/EnergyTower.asset
+++ b/Red Strike/Assets/BuildingPlacement/Buildings/EnergyTower/EnergyTower.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   buildingName: Energy Tower
   buildingPrefab: {fileID: 1944538178676760682, guid: 85da885807e881b4a911c69742b4cab6, type: 3}
-  maxHealth: 150
-  buildTime: 3.51
-  maxCreatableCount: 3
+  maxHealth: 600
+  buildTime: 4
+  maxCreatableCount: 5
   heightOffset: 5
   explosionEffect: {fileID: 198583976904112864, guid: 9bbfeaaa738e709448c6278c993f9fb8, type: 3}

--- a/Red Strike/Assets/BuildingPlacement/Buildings/Hangar/Hangar.asset
+++ b/Red Strike/Assets/BuildingPlacement/Buildings/Hangar/Hangar.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   buildingName: Hangar
   buildingPrefab: {fileID: 4298143258487221820, guid: 4b5c1b1b00d4a804aaaa616ab88ccd5f, type: 3}
-  maxHealth: 300
-  buildTime: 3.51
+  maxHealth: 1500
+  buildTime: 8
   maxCreatableCount: 2
   heightOffset: 7
   explosionEffect: {fileID: 198583976904112864, guid: 9bbfeaaa738e709448c6278c993f9fb8, type: 3}

--- a/Red Strike/Assets/BuildingPlacement/Buildings/MainStation/MainStation.asset
+++ b/Red Strike/Assets/BuildingPlacement/Buildings/MainStation/MainStation.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   buildingName: Main Station
   buildingPrefab: {fileID: 5568703836926053903, guid: ae512f537d66646498dea44801d4456b, type: 3}
-  maxHealth: 500
-  buildTime: 3.51
+  maxHealth: 3500
+  buildTime: 0
   maxCreatableCount: 1
   heightOffset: 7
   explosionEffect: {fileID: 198583976904112864, guid: 2056c3afdbd65d24f9d649085aed0898, type: 3}

--- a/Red Strike/Assets/NetworkingSystem/CommanderData.cs
+++ b/Red Strike/Assets/NetworkingSystem/CommanderData.cs
@@ -114,6 +114,7 @@ namespace NetworkingSystem
             string ammunitionName,
             Vector3 position,
             Quaternion rotation,
+            float damage,
             NetworkObject ownerVehicleNetObj,
             NetworkId targetId = default)
         {
@@ -134,6 +135,8 @@ namespace NetworkingSystem
                 {
                     ammunitionScript.OwnerTeamId = vehicleScript.teamId;
                     ammunitionScript.OwnerVehicleId = ownerVehicleNetObj.Id;
+
+                    ammunitionScript.damage = damage;
 
                     if (ammunitionData.ammunitionType == AmmunitionSystem.AmmunitionType.Rocket && targetId.IsValid)
                     {

--- a/Red Strike/Assets/PlanetAtmosphereSystem/AtmosphereMaterial.mat
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/AtmosphereMaterial.mat
@@ -47,7 +47,7 @@ Material:
     - _GunesYonu: {r: -0.91, g: 0.4, b: 3.24, a: 0}
     - _RenkUzak: {r: 0, g: 0.10166844, b: 2.152374, a: 1}
     - _RenkYakin: {r: 0, g: 5.670685, b: 8, a: 1}
-    - _SunDirection: {r: 0.117058024, g: -0.7386313, b: -0.6638685, a: 0}
+    - _SunDirection: {r: 0.100319535, g: -0.8162374, b: -0.56893986, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
 --- !u!114 &1522106816477559216

--- a/Red Strike/Assets/PlanetAtmosphereSystem/CloudMaterial.mat
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/CloudMaterial.mat
@@ -43,7 +43,7 @@ Material:
     m_Colors:
     - _Color: {r: 0, g: 3.8274493, b: 5.992155, a: 1}
     - _GunesYonu: {r: -1, g: 0, b: 0, a: 0}
-    - _SunDirection: {r: 0.117058024, g: -0.7386313, b: -0.6638685, a: 0}
+    - _SunDirection: {r: 0.100319535, g: -0.8162374, b: -0.56893986, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
 --- !u!114 &8499732345945835446

--- a/Red Strike/Assets/PlanetAtmosphereSystem/FogMaterial.mat
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/FogMaterial.mat
@@ -54,6 +54,6 @@ Material:
     - _QueueControl: 0
     - _QueueOffset: 0
     m_Colors:
-    - _SunDirection: {r: 0.117058024, g: -0.7386313, b: -0.6638685, a: 0}
+    - _SunDirection: {r: 0.100319535, g: -0.8162374, b: -0.56893986, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1

--- a/Red Strike/Assets/VehicleSystem/VehicleAmmunition.cs
+++ b/Red Strike/Assets/VehicleSystem/VehicleAmmunition.cs
@@ -9,7 +9,9 @@ namespace VehicleSystem
         public bool isEnabled;
         public AmmunitionType ammunitionType;
         public int maxAmmunition;
-        public float reloadTime;
+        [Range(0f, 5f)] public float fireRate;
+        [Range(0f, 10f)] public float reloadTime;
+        public float damage;
         public Ammunition ammunition;
         public AudioClip sound;
     }

--- a/Red Strike/Assets/VehicleSystem/Vehicles/Infantry/Infantry.asset
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/Infantry/Infantry.asset
@@ -16,19 +16,21 @@ MonoBehaviour:
   vehicleType: 0
   vehiclePrefab: {fileID: 6427180487138741020, guid: 652e336fe8416d44694bb7c08b2b9f16, type: 3}
   maxCreatableCount: 10
-  speed: 10
+  speed: 45
   coverageAreaRadius: 50
-  turnSpeed: 120
+  turnSpeed: 360
   stoppingDistance: 30
-  maxHealth: 100
-  fuelCapacity: 100
-  fuelConsumptionRate: 0.8
+  maxHealth: 60
+  fuelCapacity: 200
+  fuelConsumptionRate: 0.5
   explosionEffect: {fileID: 198016111470434822, guid: 351b5b76ddf0a404d9550315f99917aa, type: 3}
   engineSound: {fileID: 8300000, guid: 562985ad4f17daf459be53f57ff683ed, type: 3}
   ammunitionSettings:
   - isEnabled: 1
     ammunitionType: 0
     maxAmmunition: 30
-    reloadTime: 0.1
+    fireRate: 0.2
+    reloadTime: 1.5
+    damage: 10
     ammunition: {fileID: 11400000, guid: 22882af161684a743a3776628e0fe427, type: 2}
     sound: {fileID: 8300000, guid: d5b5e2c15b44f454697bfc7c719bc907, type: 3}

--- a/Red Strike/Assets/VehicleSystem/Vehicles/Infantry/Infantry.cs
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/Infantry/Infantry.cs
@@ -26,6 +26,7 @@ namespace VehicleSystem.Vehicles.Infantry
                 ammunition_bullet.ammunitionName,
                 barrelPoint.position,
                 barrelPoint.rotation,
+                vehicleData.ammunitionSettings[0].damage,
                 Object);
 
             currentAmmunition_bullet--;

--- a/Red Strike/Assets/VehicleSystem/Vehicles/Infantry/InfantryAnimController.controller
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/Infantry/InfantryAnimController.controller
@@ -33,10 +33,10 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: 5135578736379982392}
-    m_Position: {x: 200, y: 0, z: 0}
+    m_Position: {x: 350, y: -10, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 2381701427170268501}
-    m_Position: {x: 235, y: 65, z: 0}
+    m_Position: {x: 350, y: 200, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []

--- a/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterA/OrnithopterA.asset
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterA/OrnithopterA.asset
@@ -15,26 +15,30 @@ MonoBehaviour:
   vehicleName: Ornithopter A
   vehicleType: 6
   vehiclePrefab: {fileID: 6284546322829207217, guid: a35a82b670e35ac4aa3594152075595d, type: 3}
-  maxCreatableCount: 2
-  speed: 50
+  maxCreatableCount: 3
+  speed: 70
   coverageAreaRadius: 50
   turnSpeed: 5
   stoppingDistance: 15
-  maxHealth: 100
+  maxHealth: 150
   fuelCapacity: 100
-  fuelConsumptionRate: 0.2
+  fuelConsumptionRate: 2
   explosionEffect: {fileID: 198016111470434822, guid: 351b5b76ddf0a404d9550315f99917aa, type: 3}
   engineSound: {fileID: 8300000, guid: 32a3d35579b41a04f9dd0845610b1c77, type: 3}
   ammunitionSettings:
   - isEnabled: 1
     ammunitionType: 0
-    maxAmmunition: 30
-    reloadTime: 0.2
+    maxAmmunition: 40
+    fireRate: 0.1
+    reloadTime: 3
+    damage: 12
     ammunition: {fileID: 11400000, guid: 22882af161684a743a3776628e0fe427, type: 2}
     sound: {fileID: 8300000, guid: d5b5e2c15b44f454697bfc7c719bc907, type: 3}
   - isEnabled: 1
     ammunitionType: 2
-    maxAmmunition: 2
-    reloadTime: 10
+    maxAmmunition: 10
+    fireRate: 1
+    reloadTime: 8
+    damage: 150
     ammunition: {fileID: 11400000, guid: 7199de5af23451c4ca4d2919b6b44983, type: 2}
     sound: {fileID: 8300000, guid: ed5f1d53c8149d045a79feb222f5eafe, type: 3}

--- a/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterA/OrnithopterA.cs
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterA/OrnithopterA.cs
@@ -62,6 +62,7 @@ namespace VehicleSystem.Vehicles.OrnithopterA
                     ammunition_bullet.ammunitionName, 
                     spawnPoint.position, 
                     fireRot, 
+                    vehicleData.ammunitionSettings[0].damage,
                     Object
                 );
 
@@ -82,7 +83,8 @@ namespace VehicleSystem.Vehicles.OrnithopterA
             CommanderData.LocalCommander.RPC_SpawnAmmunition(
                 ammunition_rocket.ammunitionName, 
                 currentPoint.position, 
-                currentPoint.rotation, 
+                currentPoint.rotation,
+                vehicleData.ammunitionSettings[1].damage, 
                 Object, 
                 targetId
             );

--- a/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterB/OrnithopterB.asset
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterB/OrnithopterB.asset
@@ -16,25 +16,29 @@ MonoBehaviour:
   vehicleType: 7
   vehiclePrefab: {fileID: 2571774317061937991, guid: cf72a38b114e423489886ad4e9090c4e, type: 3}
   maxCreatableCount: 2
-  speed: 50
+  speed: 60
   coverageAreaRadius: 50
   turnSpeed: 5
   stoppingDistance: 15
-  maxHealth: 100
-  fuelCapacity: 100
-  fuelConsumptionRate: 0.7
+  maxHealth: 300
+  fuelCapacity: 150
+  fuelConsumptionRate: 1.5
   explosionEffect: {fileID: 19800006, guid: e0609132424a24844b1d53ad3d704fd9, type: 3}
   engineSound: {fileID: 8300000, guid: 32a3d35579b41a04f9dd0845610b1c77, type: 3}
   ammunitionSettings:
   - isEnabled: 1
     ammunitionType: 0
     maxAmmunition: 30
-    reloadTime: 0.1
+    fireRate: 0.2
+    reloadTime: 4
+    damage: 25
     ammunition: {fileID: 11400000, guid: 22882af161684a743a3776628e0fe427, type: 2}
     sound: {fileID: 8300000, guid: d5b5e2c15b44f454697bfc7c719bc907, type: 3}
   - isEnabled: 1
     ammunitionType: 2
-    maxAmmunition: 4
-    reloadTime: 1
+    maxAmmunition: 6
+    fireRate: 1.5
+    reloadTime: 10
+    damage: 300
     ammunition: {fileID: 11400000, guid: 7199de5af23451c4ca4d2919b6b44983, type: 2}
     sound: {fileID: 8300000, guid: ed5f1d53c8149d045a79feb222f5eafe, type: 3}

--- a/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterB/OrnithopterB.cs
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/OrnithopterB/OrnithopterB.cs
@@ -60,6 +60,7 @@ namespace VehicleSystem.Vehicles.OrnithopterB
                     ammunition_bullet.ammunitionName, 
                     point.position, 
                     rotation, 
+                    vehicleData.ammunitionSettings[0].damage,
                     Object
                 );
 
@@ -111,6 +112,7 @@ namespace VehicleSystem.Vehicles.OrnithopterB
                 ammunition_rocket.ammunitionName, 
                 spawnPoint.position, 
                 spawnPoint.rotation, 
+                vehicleData.ammunitionSettings[1].damage,
                 Object, 
                 targetId
             );

--- a/Red Strike/Assets/VehicleSystem/Vehicles/Quad/Quad.asset
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/Quad/Quad.asset
@@ -16,19 +16,21 @@ MonoBehaviour:
   vehicleType: 2
   vehiclePrefab: {fileID: 8322101594408336133, guid: 16678156d05891545a8ea7f1b6b4e7f6, type: 3}
   maxCreatableCount: 5
-  speed: 10
+  speed: 35
   coverageAreaRadius: 50
-  turnSpeed: 120
+  turnSpeed: 100
   stoppingDistance: 35
-  maxHealth: 100
-  fuelCapacity: 100
-  fuelConsumptionRate: 0.7
+  maxHealth: 250
+  fuelCapacity: 300
+  fuelConsumptionRate: 0.4
   explosionEffect: {fileID: 198016111470434822, guid: 351b5b76ddf0a404d9550315f99917aa, type: 3}
   engineSound: {fileID: 8300000, guid: 562985ad4f17daf459be53f57ff683ed, type: 3}
   ammunitionSettings:
   - isEnabled: 1
     ammunitionType: 0
-    maxAmmunition: 30
-    reloadTime: 0.1
+    maxAmmunition: 36
+    fireRate: 0.3
+    reloadTime: 2.5
+    damage: 18
     ammunition: {fileID: 11400000, guid: 22882af161684a743a3776628e0fe427, type: 2}
     sound: {fileID: 8300000, guid: d5b5e2c15b44f454697bfc7c719bc907, type: 3}

--- a/Red Strike/Assets/VehicleSystem/Vehicles/Quad/Quad.cs
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/Quad/Quad.cs
@@ -31,6 +31,7 @@ namespace VehicleSystem.Vehicles.Quad
                     ammunition_bullet.ammunitionName, 
                     barrelPoint_A.position, 
                     barrelPoint_A.rotation, 
+                    vehicleData.ammunitionSettings[0].damage,
                     Object
                 );
                 currentAmmunition_bullet--;
@@ -42,6 +43,7 @@ namespace VehicleSystem.Vehicles.Quad
                     ammunition_bullet.ammunitionName, 
                     barrelPoint_B.position, 
                     barrelPoint_B.rotation, 
+                    vehicleData.ammunitionSettings[0].damage,
                     Object
                 );
                 currentAmmunition_bullet--;

--- a/Red Strike/Assets/VehicleSystem/Vehicles/TankCombat/TankCombat.asset
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/TankCombat/TankCombat.asset
@@ -16,19 +16,21 @@ MonoBehaviour:
   vehicleType: 3
   vehiclePrefab: {fileID: 3852297137727675049, guid: 9cf1c748f66b08149a5dd3ff27cb2a9b, type: 3}
   maxCreatableCount: 4
-  speed: 10
+  speed: 25
   coverageAreaRadius: 50
-  turnSpeed: 120
+  turnSpeed: 40
   stoppingDistance: 40
-  maxHealth: 100
-  fuelCapacity: 100
-  fuelConsumptionRate: 0.9
+  maxHealth: 500
+  fuelCapacity: 400
+  fuelConsumptionRate: 0.3
   explosionEffect: {fileID: 198016111470434822, guid: 351b5b76ddf0a404d9550315f99917aa, type: 3}
   engineSound: {fileID: 8300000, guid: 1a9227f4b0059084ebfab2f7f0119f9b, type: 3}
   ammunitionSettings:
   - isEnabled: 1
     ammunitionType: 0
     maxAmmunition: 20
-    reloadTime: 1
+    fireRate: 2
+    reloadTime: 5
+    damage: 120
     ammunition: {fileID: 11400000, guid: 5ef71d70c67b5bc4d964f8e71bd005ea, type: 2}
     sound: {fileID: 8300000, guid: 14866e6df058b894085e07d269b0a39f, type: 3}

--- a/Red Strike/Assets/VehicleSystem/Vehicles/TankCombat/TankCombat.cs
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/TankCombat/TankCombat.cs
@@ -24,7 +24,13 @@ namespace VehicleSystem.Vehicles.TankCombat
         {
             base.FireShot();
 
-            CommanderData.LocalCommander.RPC_SpawnAmmunition(ammunition_bullet.ammunitionName, barrelPoint.position, barrelPoint.rotation, Object);
+            CommanderData.LocalCommander.RPC_SpawnAmmunition(
+                ammunition_bullet.ammunitionName, 
+                barrelPoint.position, 
+                barrelPoint.rotation, 
+                vehicleData.ammunitionSettings[0].damage, 
+                Object
+            );
             currentAmmunition_bullet--;
         }
 

--- a/Red Strike/Assets/VehicleSystem/Vehicles/TankHeavyA/TankHeavyA.cs
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/TankHeavyA/TankHeavyA.cs
@@ -24,7 +24,13 @@ namespace VehicleSystem.Vehicles.TankHeavyA
         {
             base.FireShot();
 
-            CommanderData.LocalCommander.RPC_SpawnAmmunition(ammunition_bullet.ammunitionName, barrelPoint.position, barrelPoint.rotation, Object);
+            CommanderData.LocalCommander.RPC_SpawnAmmunition(
+                ammunition_bullet.ammunitionName, 
+                barrelPoint.position, 
+                barrelPoint.rotation,
+                vehicleData.ammunitionSettings[0].damage,
+                Object
+            );
             currentAmmunition_bullet--;
         }
 

--- a/Red Strike/Assets/VehicleSystem/Vehicles/TankHeavyA/TankHeavyAAnimController.asset
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/TankHeavyA/TankHeavyAAnimController.asset
@@ -15,20 +15,22 @@ MonoBehaviour:
   vehicleName: Tank Heavy A
   vehicleType: 4
   vehiclePrefab: {fileID: 8630292313461707713, guid: 5da929ed199dc6c43aa09de6252e7e4a, type: 3}
-  maxCreatableCount: 2
-  speed: 10
+  maxCreatableCount: 1
+  speed: 14
   coverageAreaRadius: 50
-  turnSpeed: 120
+  turnSpeed: 20
   stoppingDistance: 40
-  maxHealth: 100
-  fuelCapacity: 100
-  fuelConsumptionRate: 0.7
+  maxHealth: 1200
+  fuelCapacity: 600
+  fuelConsumptionRate: 0.1
   explosionEffect: {fileID: 198016111470434822, guid: 351b5b76ddf0a404d9550315f99917aa, type: 3}
   engineSound: {fileID: 8300000, guid: 1a9227f4b0059084ebfab2f7f0119f9b, type: 3}
   ammunitionSettings:
   - isEnabled: 1
     ammunitionType: 0
     maxAmmunition: 10
+    fireRate: 5
     reloadTime: 10
+    damage: 450
     ammunition: {fileID: 11400000, guid: 5ef71d70c67b5bc4d964f8e71bd005ea, type: 2}
     sound: {fileID: 8300000, guid: 14866e6df058b894085e07d269b0a39f, type: 3}

--- a/Red Strike/Assets/VehicleSystem/Vehicles/TankHeavyB/TankHeavyB.asset
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/TankHeavyB/TankHeavyB.asset
@@ -15,20 +15,22 @@ MonoBehaviour:
   vehicleName: Tank Heavy B
   vehicleType: 5
   vehiclePrefab: {fileID: 3969752469904077645, guid: 74287606229d56b4b89524f3b409529e, type: 3}
-  maxCreatableCount: 3
-  speed: 10
+  maxCreatableCount: 2
+  speed: 18
   coverageAreaRadius: 50
-  turnSpeed: 120
+  turnSpeed: 30
   stoppingDistance: 40
-  maxHealth: 100
-  fuelCapacity: 100
-  fuelConsumptionRate: 0.7
+  maxHealth: 800
+  fuelCapacity: 500
+  fuelConsumptionRate: 0.2
   explosionEffect: {fileID: 198016111470434822, guid: 351b5b76ddf0a404d9550315f99917aa, type: 3}
   engineSound: {fileID: 8300000, guid: 1a9227f4b0059084ebfab2f7f0119f9b, type: 3}
   ammunitionSettings:
   - isEnabled: 1
     ammunitionType: 0
     maxAmmunition: 15
+    fireRate: 3.5
     reloadTime: 7
+    damage: 250
     ammunition: {fileID: 11400000, guid: 5ef71d70c67b5bc4d964f8e71bd005ea, type: 2}
     sound: {fileID: 8300000, guid: 14866e6df058b894085e07d269b0a39f, type: 3}

--- a/Red Strike/Assets/VehicleSystem/Vehicles/TankHeavyB/TankHeavyB.cs
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/TankHeavyB/TankHeavyB.cs
@@ -24,7 +24,13 @@ namespace VehicleSystem.Vehicles.TankHeavyB
         {
             base.FireShot();
 
-            CommanderData.LocalCommander.RPC_SpawnAmmunition(ammunition_bullet.ammunitionName, barrelPoint.position, barrelPoint.rotation, Object);
+            CommanderData.LocalCommander.RPC_SpawnAmmunition(
+                ammunition_bullet.ammunitionName, 
+                barrelPoint.position, 
+                barrelPoint.rotation, 
+                vehicleData.ammunitionSettings[0].damage,
+                Object
+            );
             currentAmmunition_bullet--;
         }
 

--- a/Red Strike/Assets/VehicleSystem/Vehicles/Trike/Trike.asset
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/Trike/Trike.asset
@@ -15,20 +15,22 @@ MonoBehaviour:
   vehicleName: Trike
   vehicleType: 1
   vehiclePrefab: {fileID: 7311248439144974317, guid: 37c4c0d8afa72df4998c6da17046515b, type: 3}
-  maxCreatableCount: 5
-  speed: 20
+  maxCreatableCount: 7
+  speed: 40
   coverageAreaRadius: 20
   turnSpeed: 120
   stoppingDistance: 40
-  maxHealth: 100
-  fuelCapacity: 100
-  fuelConsumptionRate: 0.7
+  maxHealth: 120
+  fuelCapacity: 250
+  fuelConsumptionRate: 0.45
   explosionEffect: {fileID: 198016111470434822, guid: 351b5b76ddf0a404d9550315f99917aa, type: 3}
   engineSound: {fileID: 8300000, guid: 562985ad4f17daf459be53f57ff683ed, type: 3}
   ammunitionSettings:
   - isEnabled: 1
     ammunitionType: 0
     maxAmmunition: 30
-    reloadTime: 0.17
+    fireRate: 0.25
+    reloadTime: 2
+    damage: 15
     ammunition: {fileID: 11400000, guid: 22882af161684a743a3776628e0fe427, type: 2}
     sound: {fileID: 8300000, guid: d5b5e2c15b44f454697bfc7c719bc907, type: 3}

--- a/Red Strike/Assets/VehicleSystem/Vehicles/Trike/Trike.cs
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/Trike/Trike.cs
@@ -23,7 +23,13 @@ namespace VehicleSystem.Vehicles.Trike
         {
             base.FireShot();
 
-            CommanderData.LocalCommander.RPC_SpawnAmmunition(ammunition_bullet.ammunitionName, barrelPoint.position, barrelPoint.rotation, Object);
+            CommanderData.LocalCommander.RPC_SpawnAmmunition(
+                ammunition_bullet.ammunitionName,
+                barrelPoint.position,
+                barrelPoint.rotation,
+                vehicleData.ammunitionSettings[0].damage,
+                Object
+            );
             currentAmmunition_bullet--;
         }
 

--- a/Red Strike/Assets/VehicleSystem/Vehicles/Vehicle.cs
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/Vehicle.cs
@@ -181,9 +181,14 @@ namespace VehicleSystem.Vehicles
             }
         }
 
-        public (string, float, int, int, float) GetVehicleStatus()
+        public (string, float, int, int, float, int, int) GetVehicleStatus()
         {
-            return (vehicleData.vehicleName, fuelLevel, currentAmmunition_bullet, bulletAmmunitionSettings.maxAmmunition, health);
+            return (
+                vehicleData.vehicleName,
+                fuelLevel, currentAmmunition_bullet,
+                bulletAmmunitionSettings.maxAmmunition,
+                health, reloadCounter_bullet, reloadCounter_rocket
+                );
         }
 
         public (int currentRockets, int maxRockets) GetRocketStatus()
@@ -300,12 +305,12 @@ namespace VehicleSystem.Vehicles
                     EnableMuzzleFlashEffects();
                     Invoke("DisableMuzzleFlashLights", 0.1f);
 
-                    bulletCooldownTimer = bulletAmmunitionSettings.reloadTime;
+                    bulletCooldownTimer = bulletAmmunitionSettings.fireRate;
                 }
                 else
                 {
-                    ReloadAmmunition();
-                    bulletCooldownTimer = bulletAmmunitionSettings.reloadTime * 2;
+                    Invoke(nameof(ReloadAmmunition), bulletAmmunitionSettings.reloadTime);
+                    bulletCooldownTimer = bulletAmmunitionSettings.fireRate * 2;
                 }
             }
         }
@@ -323,12 +328,12 @@ namespace VehicleSystem.Vehicles
                     EnableMuzzleFlashEffects();
                     Invoke(nameof(DisableMuzzleFlashLights), 0.1f);
 
-                    rocketCooldownTimer = rocketAmmunitionSettings.reloadTime;
+                    rocketCooldownTimer = rocketAmmunitionSettings.fireRate;
                 }
                 else
                 {
-                    ReloadRocketAmmunition();
-                    rocketCooldownTimer = rocketAmmunitionSettings.reloadTime * 2;
+                    Invoke(nameof(ReloadRocketAmmunition), rocketAmmunitionSettings.reloadTime);
+                    rocketCooldownTimer = rocketAmmunitionSettings.fireRate * 2;
                 }
             }
         }
@@ -375,6 +380,7 @@ namespace VehicleSystem.Vehicles
 
         protected virtual void ReloadAmmunition()
         {
+            reloadCounter_bullet++;
             currentAmmunition_bullet = bulletAmmunitionSettings.maxAmmunition;
         }
 
@@ -382,6 +388,7 @@ namespace VehicleSystem.Vehicles
         {
             if (rocketAmmunitionSettings != null)
             {
+                reloadCounter_rocket++;
                 currentAmmunition_rocket = rocketAmmunitionSettings.maxAmmunition;
             }
         }


### PR DESCRIPTION
Moved the damage property from AmmunitionData to individual ammunition instances and updated all usages accordingly. Vehicle and building stats were rebalanced, including health, speed, fuel, and ammunition parameters. Added fireRate and damage fields to VehicleAmmunition, and updated vehicle firing logic to use these new parameters. Improved status reporting and reload tracking in Vehicle.cs. Adjusted material sun direction vectors for atmosphere visuals.