### PR TITLE
Update unit prefabs and materials for movement and sun direction

### DIFF
--- a/Red Strike/Assets/PlanetAtmosphereSystem/AtmosphereMaterial.mat
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/AtmosphereMaterial.mat
@@ -47,7 +47,7 @@ Material:
     - _GunesYonu: {r: -0.91, g: 0.4, b: 3.24, a: 0}
     - _RenkUzak: {r: 0, g: 0.10166844, b: 2.152374, a: 1}
     - _RenkYakin: {r: 0, g: 5.670685, b: 8, a: 1}
-    - _SunDirection: {r: 0.10851663, g: -0.78068715, b: -0.61542803, a: 0}
+    - _SunDirection: {r: 0.1483191, g: -0.52005136, b: -0.84115875, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
 --- !u!114 &1522106816477559216

--- a/Red Strike/Assets/PlanetAtmosphereSystem/CloudMaterial.mat
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/CloudMaterial.mat
@@ -43,7 +43,7 @@ Material:
     m_Colors:
     - _Color: {r: 0, g: 3.8274493, b: 5.992155, a: 1}
     - _GunesYonu: {r: -1, g: 0, b: 0, a: 0}
-    - _SunDirection: {r: 0.10851663, g: -0.78068715, b: -0.61542803, a: 0}
+    - _SunDirection: {r: 0.1483191, g: -0.52005136, b: -0.84115875, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
 --- !u!114 &8499732345945835446

--- a/Red Strike/Assets/PlanetAtmosphereSystem/FogMaterial.mat
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/FogMaterial.mat
@@ -54,6 +54,6 @@ Material:
     - _QueueControl: 0
     - _QueueOffset: 0
     m_Colors:
-    - _SunDirection: {r: 0.10851663, g: -0.78068715, b: -0.61542803, a: 0}
+    - _SunDirection: {r: 0.1483191, g: -0.52005136, b: -0.84115875, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1

--- a/Red Strike/Assets/Resources/Infantry.prefab
+++ b/Red Strike/Assets/Resources/Infantry.prefab
@@ -5380,7 +5380,7 @@ NavMeshAgent:
   m_AgentTypeID: 0
   m_Radius: 0.5
   m_Speed: 3.5
-  m_Acceleration: 8
+  m_Acceleration: 70
   avoidancePriority: 50
   m_AngularSpeed: 120
   m_StoppingDistance: 0
@@ -5473,6 +5473,9 @@ MonoBehaviour:
   lowEnergyThreshold: 0.3
   _TargetNetworkId:
     Raw: 0
+  _TargetMovePosition: {x: 0, y: 0, z: 0}
+  _IsMovingToPosition: 0
+  _fuelLevel: 0
   engineSource: {fileID: 6058987034765308819}
   animator: {fileID: 7699472609279259922}
   rocketAttackRange: 40
@@ -5508,7 +5511,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d3e01160669f82e499d3f5c9fdb4eebc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  selectionColor: {r: 0, g: 0.30980393, b: 1, a: 1}
 --- !u!114 &6855712048071949838
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Red Strike/Assets/Resources/Quad.prefab
+++ b/Red Strike/Assets/Resources/Quad.prefab
@@ -5335,7 +5335,7 @@ NavMeshAgent:
   m_AgentTypeID: 0
   m_Radius: 2.44
   m_Speed: 3.5
-  m_Acceleration: 8
+  m_Acceleration: 70
   avoidancePriority: 50
   m_AngularSpeed: 120
   m_StoppingDistance: 0
@@ -5430,6 +5430,9 @@ MonoBehaviour:
   lowEnergyThreshold: 0.3
   _TargetNetworkId:
     Raw: 0
+  _TargetMovePosition: {x: 0, y: 0, z: 0}
+  _IsMovingToPosition: 0
+  _fuelLevel: 0
   engineSource: {fileID: 7040296906606052471}
   animator: {fileID: 1362993600178568906}
   rocketAttackRange: 40
@@ -5482,7 +5485,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d3e01160669f82e499d3f5c9fdb4eebc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  selectionColor: {r: 0, g: 0.30699968, b: 1, a: 1}
 --- !u!82 &6342048877260788982
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Red Strike/Assets/Resources/TankCombat.prefab
+++ b/Red Strike/Assets/Resources/TankCombat.prefab
@@ -4925,7 +4925,7 @@ NavMeshAgent:
   m_AgentTypeID: 0
   m_Radius: 3.18
   m_Speed: 3.5
-  m_Acceleration: 8
+  m_Acceleration: 70
   avoidancePriority: 50
   m_AngularSpeed: 120
   m_StoppingDistance: 0
@@ -4981,6 +4981,9 @@ MonoBehaviour:
   lowEnergyThreshold: 0.3
   _TargetNetworkId:
     Raw: 0
+  _TargetMovePosition: {x: 0, y: 0, z: 0}
+  _IsMovingToPosition: 0
+  _fuelLevel: 0
   engineSource: {fileID: 681241975874448737}
   animator: {fileID: 3600975313029927869}
   rocketAttackRange: 40
@@ -5054,7 +5057,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d3e01160669f82e499d3f5c9fdb4eebc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  selectionColor: {r: 0, g: 0.30980393, b: 1, a: 1}
 --- !u!114 &3587256659096845638
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Red Strike/Assets/Resources/TankHeavyA.prefab
+++ b/Red Strike/Assets/Resources/TankHeavyA.prefab
@@ -5312,7 +5312,7 @@ NavMeshAgent:
   m_AgentTypeID: 0
   m_Radius: 4.41
   m_Speed: 3.5
-  m_Acceleration: 8
+  m_Acceleration: 70
   avoidancePriority: 50
   m_AngularSpeed: 120
   m_StoppingDistance: 0
@@ -5405,6 +5405,9 @@ MonoBehaviour:
   lowEnergyThreshold: 0.3
   _TargetNetworkId:
     Raw: 0
+  _TargetMovePosition: {x: 0, y: 0, z: 0}
+  _IsMovingToPosition: 0
+  _fuelLevel: 0
   engineSource: {fileID: 8344803449278041535}
   animator: {fileID: 5007558135761398548}
   rocketAttackRange: 40
@@ -5441,7 +5444,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d3e01160669f82e499d3f5c9fdb4eebc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  selectionColor: {r: 0, g: 0.30980393, b: 1, a: 1}
 --- !u!114 &5259369918086251800
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Red Strike/Assets/Resources/TankHeavyB.prefab
+++ b/Red Strike/Assets/Resources/TankHeavyB.prefab
@@ -372,7 +372,7 @@ NavMeshAgent:
   m_AgentTypeID: 0
   m_Radius: 4.42
   m_Speed: 3.5
-  m_Acceleration: 8
+  m_Acceleration: 70
   avoidancePriority: 50
   m_AngularSpeed: 120
   m_StoppingDistance: 0
@@ -465,6 +465,9 @@ MonoBehaviour:
   lowEnergyThreshold: 0.3
   _TargetNetworkId:
     Raw: 0
+  _TargetMovePosition: {x: 0, y: 0, z: 0}
+  _IsMovingToPosition: 0
+  _fuelLevel: 0
   engineSource: {fileID: 595451111231717810}
   animator: {fileID: 3908224367845254761}
   rocketAttackRange: 40
@@ -501,7 +504,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d3e01160669f82e499d3f5c9fdb4eebc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  selectionColor: {r: 0, g: 0.30980393, b: 1, a: 1}
 --- !u!114 &5437171139404782462
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Red Strike/Assets/Resources/Trike.prefab
+++ b/Red Strike/Assets/Resources/Trike.prefab
@@ -5516,7 +5516,7 @@ NavMeshAgent:
   m_AgentTypeID: 0
   m_Radius: 1.65
   m_Speed: 3.5
-  m_Acceleration: 8
+  m_Acceleration: 70
   avoidancePriority: 50
   m_AngularSpeed: 120
   m_StoppingDistance: 0
@@ -5609,6 +5609,9 @@ MonoBehaviour:
   lowEnergyThreshold: 0.3
   _TargetNetworkId:
     Raw: 0
+  _TargetMovePosition: {x: 0, y: 0, z: 0}
+  _IsMovingToPosition: 0
+  _fuelLevel: 0
   engineSource: {fileID: 7716342696854761872}
   animator: {fileID: 574273482213751387}
   rocketAttackRange: 40
@@ -5644,7 +5647,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d3e01160669f82e499d3f5c9fdb4eebc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  selectionColor: {r: 0, g: 0.30980393, b: 1, a: 1}
 --- !u!82 &1947969905624286606
 AudioSource:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Increased NavMeshAgent acceleration from 8 to 70 for all major unit prefabs (Infantry, Quad, TankCombat, TankHeavyA, TankHeavyB, Trike) and added new movement-related fields (_TargetMovePosition, _IsMovingToPosition, _fuelLevel) to their MonoBehaviours. Removed selectionColor property from these prefabs. Updated _SunDirection values in AtmosphereMaterial, CloudMaterial, and FogMaterial to new vector values.