### PR TITLE
Improve path visualization and team checks for vehicles

### DIFF
--- a/Red Strike/Assets/BuildingPlacement/Buildings/Hangar/Hangar.cs
+++ b/Red Strike/Assets/BuildingPlacement/Buildings/Hangar/Hangar.cs
@@ -28,11 +28,7 @@ namespace BuildingPlacement.Buildings
         {
             var targetVehicleData = vehiclesDatabase.vehicles.FirstOrDefault(v => v.vehicleType == vehicleType);
 
-            if (targetVehicleData == null) 
-            {
-                //Debug.LogError("Araç database'de bulunamadı!");
-                return;
-            }
+            if (targetVehicleData == null) return;
 
             bool limitReached = GameStateManager.Instance.HasReachedLimit(
                 teamId,
@@ -42,7 +38,6 @@ namespace BuildingPlacement.Buildings
 
             if (limitReached)
             {
-                //Debug.LogWarning("Araç limitine ulaşıldı!");
                 NotificationSystem.NotificationSystem.Show(
                     "Vehicle Creation Error",
                     "You have reached the limit for creating " + targetVehicleData.vehicleName + ".",

--- a/Red Strike/Assets/GameStateSystem/GameStateManager.cs
+++ b/Red Strike/Assets/GameStateSystem/GameStateManager.cs
@@ -14,7 +14,7 @@ namespace GameStateSystem
         [Networked] public int WinningTeamId { get; set; } = -1;
         public int LocalPlayerTeamId = 0;
 
-        [Networked, Capacity(32)]
+        [Networked, Capacity(128)]
         private NetworkDictionary<NetworkString<_32>, int> UnitCounts { get; }
 
         private ChangeDetector _changes;

--- a/Red Strike/Assets/InputController/InputController.cs
+++ b/Red Strike/Assets/InputController/InputController.cs
@@ -8,7 +8,6 @@ using NetworkingSystem;
 using AmmunitionSystem;
 using UserSystem;
 using GameStateSystem;
-using ExitGames.Client.Photon.StructWrapping;
 
 namespace InputController
 {

--- a/Red Strike/Assets/InputController/PathVisualizer.cs
+++ b/Red Strike/Assets/InputController/PathVisualizer.cs
@@ -47,6 +47,17 @@ namespace InputController
             }
         }
 
+        public void ShowPoints(Vector3[] points, PathColor color)
+        {
+            if (points == null || points.Length < 2)
+            {
+                HidePath();
+                return;
+            }
+
+            DrawLineInternal(points, color);
+        }
+
         public void ShowNavMeshPath(PathColor color)
         {
             if (agent == null || !agent.hasPath)

--- a/Red Strike/Assets/PlanetAtmosphereSystem/AtmosphereMaterial.mat
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/AtmosphereMaterial.mat
@@ -47,7 +47,7 @@ Material:
     - _GunesYonu: {r: -0.91, g: 0.4, b: 3.24, a: 0}
     - _RenkUzak: {r: 0, g: 0.10166844, b: 2.152374, a: 1}
     - _RenkYakin: {r: 0, g: 5.670685, b: 8, a: 1}
-    - _SunDirection: {r: 0.17163001, g: -0.15202178, b: -0.97336143, a: 0}
+    - _SunDirection: {r: -0.13354853, g: -0.63915896, b: 0.757391, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
 --- !u!114 &1522106816477559216

--- a/Red Strike/Assets/PlanetAtmosphereSystem/CloudMaterial.mat
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/CloudMaterial.mat
@@ -43,7 +43,7 @@ Material:
     m_Colors:
     - _Color: {r: 0, g: 3.8274493, b: 5.992155, a: 1}
     - _GunesYonu: {r: -1, g: 0, b: 0, a: 0}
-    - _SunDirection: {r: 0.17163001, g: -0.15202178, b: -0.97336143, a: 0}
+    - _SunDirection: {r: -0.13354853, g: -0.63915896, b: 0.757391, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
 --- !u!114 &8499732345945835446

--- a/Red Strike/Assets/PlanetAtmosphereSystem/FogMaterial.mat
+++ b/Red Strike/Assets/PlanetAtmosphereSystem/FogMaterial.mat
@@ -54,6 +54,6 @@ Material:
     - _QueueControl: 0
     - _QueueOffset: 0
     m_Colors:
-    - _SunDirection: {r: 0.17163001, g: -0.15202178, b: -0.97336143, a: 0}
+    - _SunDirection: {r: -0.13354853, g: -0.63915896, b: 0.757391, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1

--- a/Red Strike/Assets/VehicleSystem/Vehicles/AirVehicle.cs
+++ b/Red Strike/Assets/VehicleSystem/Vehicles/AirVehicle.cs
@@ -87,6 +87,18 @@ namespace VehicleSystem.Vehicles
         {
             if (pathVisualizer == null) return;
 
+            bool isMyTeam = false;
+            if (InputController.InputController.Instance != null)
+            {
+                isMyTeam = (InputController.InputController.Instance.teamId == this.teamId);
+            }
+
+            if (!isMyTeam)
+            {
+                pathVisualizer.HidePath();
+                return;
+            }
+
             if (fuelLevel <= 0 || isRefueling)
             {
                 if (nearestEnergyTower != null)


### PR DESCRIPTION
Added team ownership checks to AirVehicle and GroundVehicle to ensure only the controlling player's team sees path visualizations. Enhanced GroundVehicle path drawing to use NavMesh calculations for clients without state authority. Added a ShowPoints method to PathVisualizer for flexible path rendering. Increased UnitCounts capacity in GameStateManager. Updated material files to adjust _SunDirection values. Removed unused import in InputController.